### PR TITLE
Move demo; clean up warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # Gradle output.
 /.gradle/
-/build/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,11 @@
-// Load plugins.
 buildscript {
   repositories {
     mavenCentral()
     jcenter()
   }
-  dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
-  }
 }
 
 apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'com.nordstrom'
 version = '0.1.0-SNAPSHOT'
@@ -53,18 +46,4 @@ dependencies {
     compile 'org.projectlombok:lombok:1.16.16'
     compile 'org.slf4j:slf4j-api:1.7.25'
     testCompile 'junit:junit:4.12'
-}
-
-// Configure protobuf build.
-protobuf {
-  // Configure the protoc executable to use the official distribution.
-  protoc {
-    artifact = 'com.google.protobuf:protoc:3.0.0'
-  }
-}
-
-shadowJar {
-  manifest {
-    attributes 'Main-Class': 'com.nordstrom.xrpc.Example'
-  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,12 @@ description = """Simple, production ready Java API server built on top of functi
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+    options.encoding = 'UTF-8'
+    // The tls package uses a ton of proprietary APIs that generate warnings. Suppress these (and fork
+    // the compiler so that the definition works).
+    options.compilerArgs += ['-XDignore.symbol.file']
+    options.fork = true
+    options.forkOptions.executable = 'javac'
 }
 
 repositories {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,0 +1,62 @@
+// Load plugins.
+buildscript {
+  repositories {
+    mavenCentral()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
+  }
+}
+
+apply plugin: 'java'
+apply plugin: 'com.google.protobuf'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+group = 'com.nordstrom'
+version = '0.1.0-SNAPSHOT'
+archivesBaseName = 'xrpc-demo'
+
+description = """xrpc demo project."""
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+tasks.withType(JavaCompile) {
+	options.encoding = 'UTF-8'
+}
+
+repositories {
+  maven { url 'http://repo.maven.apache.org/maven2' }
+}
+
+dependencies {
+  compile rootProject
+  compile 'ch.qos.logback:logback-classic:1.1.7'
+  compile 'ch.qos.logback:logback-core:1.1.7'
+  compile 'com.google.code.findbugs:jsr305:3.0.2'
+  compile 'com.google.protobuf:protobuf-java:3.0.0'
+  compile 'com.squareup.moshi:moshi:1.5.0'
+  compile 'com.squareup.okio:okio:1.13.0'
+  compile 'com.typesafe:config:1.3.1'
+  compile 'io.netty:netty-all:4.1.15.Final'
+  compile 'io.netty:netty-tcnative-boringssl-static:2.0.6.Final'
+  compile 'io.netty:netty-transport-native-epoll:4.1.15.Final'
+  compile 'org.projectlombok:lombok:1.16.16'
+  compile 'org.slf4j:slf4j-api:1.7.25'
+  testCompile 'junit:junit:4.12'
+}
+
+// Configure protobuf build.
+protobuf {
+  // Configure the protoc executable to use the official distribution.
+  protoc {
+    artifact = 'com.google.protobuf:protoc:3.0.0'
+  }
+}
+
+shadowJar {
+  manifest {
+    attributes 'Main-Class': 'com.xjeffrose.xrpc.Example'
+  }
+}

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/DinoDecoder.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/DinoDecoder.java
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package com.nordstrom.xrpc;
+package com.nordstrom.xrpc.demo;
 
-import com.nordstrom.xrpc.proto.Dino;
+import com.nordstrom.xrpc.demo.proto.Dino;
 
 import java.io.IOException;
 
-public class DinoEncoder {
-
+public class DinoDecoder {
   public static void main(String[] args) throws IOException {
-    Dino dino = Dino.newBuilder().setName(args[0]).setFavColor(args[1]).build();
-    System.out.write(dino.toByteArray());
+    byte[] bytes = new byte[System.in.available()];
+    System.in.read(bytes, 0, bytes.length);
+    Dino dino = Dino.parseFrom(bytes);
+    System.out.println(dino);
   }
+
 }

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/DinoEncoder.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/DinoEncoder.java
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package com.nordstrom.xrpc;
+package com.nordstrom.xrpc.demo;
 
-import com.nordstrom.xrpc.proto.Dino;
+import com.nordstrom.xrpc.demo.proto.Dino;
 
 import java.io.IOException;
 
-public class DinoDecoder {
-
+public class DinoEncoder {
   public static void main(String[] args) throws IOException {
-
-    byte[] bytes = new byte[System.in.available()];
-    System.in.read(bytes, 0, bytes.length);
-    Dino dino = Dino.parseFrom(bytes);
-
-    System.out.println(dino);
+    Dino dino = Dino.newBuilder().setName(args[0]).setFavColor(args[1]).build();
+    System.out.write(dino.toByteArray());
   }
-
 }

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.nordstrom.xrpc;
+package com.nordstrom.xrpc.demo;
 
 import com.nordstrom.xrpc.http.Router;
 import com.nordstrom.xrpc.http.Route;
-import com.nordstrom.xrpc.proto.Dino;
+import com.nordstrom.xrpc.demo.proto.Dino;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;

--- a/demo/src/main/proto/dino.proto
+++ b/demo/src/main/proto/dino.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package nordstrom.dino;
 
-option java_package = "com.nordstrom.xrpc.proto";
+option java_package = "com.nordstrom.xrpc.demo.proto";
 option java_multiple_files = true;
 
 message Dino {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
+include 'demo'
+
 rootProject.name = 'xrpc'


### PR DESCRIPTION
Two commits here.

The first simply configures our compiler to stop complaining about the Sun interfaces used in the `tls` package.

The second moves the demo to a subproject, in preparation for moving it somewhere else. That step requires this library be published somewhere, though, so I'm not taking it yet. :)