### PR TITLE
Mux & route changes to make the API a bit cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ public class Example {
 
 
     // Create your route mapping
-    router.addRoute("/people/:person", personHandler);
+    router.addRoute("/people/{person}", personHandler);
     router.addRoute("/people", peopleHandler);
 
     // Create your route mapping
-    router.addRoute("/dinos/:dino", dinoHandler);
+    router.addRoute("/dinos/{dino}", dinoHandler);
     router.addRoute("/dinos", dinosHandler);
 
     try {

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,17 @@ buildscript {
     mavenCentral()
     jcenter()
   }
+  dependencies {
+    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+  }
 }
 
 apply plugin: 'checkstyle'
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+// Junit 5 gradle runner.
+apply plugin: 'org.junit.platform.gradle.plugin'
 
 group = 'com.nordstrom.xrpc'
 archivesBaseName = 'xrpc'
@@ -49,7 +54,9 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.1'
     compile 'org.projectlombok:lombok:1.16.16'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    testCompile 'junit:junit:4.12'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
+    testCompile 'org.apiguardian:apiguardian-api:1.0.0'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
 }
 
 // Run with the latest checkstyle version. Required for our checkstyle.xml.

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
@@ -161,11 +161,11 @@ public class Example {
         };
 
     // Create your route mapping
-    router.addRoute("/people/:person", personHandler);
+    router.addRoute("/people/{person}", personHandler);
     router.addRoute("/people", peopleHandler);
 
     // Create your route mapping
-    router.addRoute("/dinos/:dino", dinoHandler);
+    router.addRoute("/dinos/{dino}", dinoHandler);
     router.addRoute("/dinos", dinosHandler);
 
     // Health Check for k8s

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
@@ -22,7 +22,8 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.nordstrom.xrpc.demo.proto.Dino;
-import com.nordstrom.xrpc.http.Route;
+import com.nordstrom.xrpc.http.Handler;
+import com.nordstrom.xrpc.http.Recipes;
 import com.nordstrom.xrpc.http.Router;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -32,18 +33,14 @@ import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,36 +65,24 @@ public class Example {
     Router router = new Router();
 
     // Define a simple function call
-    Function<HttpRequest, HttpResponse> peopleHandler =
-        x -> {
-          ByteBuf bb = Unpooled.compositeBuffer();
-
-          bb.writeBytes(adapter.toJson(people).getBytes(Charset.forName("UTF-8")));
-          HttpResponse response =
-              new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, bb);
-          response.headers().set(CONTENT_TYPE, "text/plain");
-          response.headers().setInt(CONTENT_LENGTH, bb.readableBytes());
-
-          return response;
+    Handler peopleHandler =
+        context -> {
+          return Recipes.newResponseOk(
+              adapter.toJson(people), Recipes.ContentType.Application_Json);
         };
 
     // Define a complex function call
-    BiFunction<HttpRequest, Route, HttpResponse> personHandler =
-        (x, y) -> {
-          Person p = new Person(y.groups(x.uri()).get("person"));
+    Handler personHandler =
+        context -> {
+          Person p = new Person(context.variable("person"));
           people.add(p);
 
-          HttpResponse response =
-              new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-          response.headers().set(CONTENT_TYPE, "text/plain");
-          response.headers().setInt(CONTENT_LENGTH, 0);
-
-          return response;
+          return Recipes.newResponseOk("");
         };
 
     // do some proto
-    Function<HttpRequest, HttpResponse> dinosHandler =
-        x -> {
+    Handler dinosHandler =
+        context -> {
           // TODO(jkinkead): Clean this up; we should have a helper to handle this.
           Dino output = dinos.get(0);
           ByteBuf bb = Unpooled.compositeBuffer();
@@ -121,15 +106,16 @@ public class Example {
         };
 
     // Define a complex function call with Proto
-    BiFunction<HttpRequest, Route, HttpResponse> dinoHandler =
-        (x, y) -> {
+    Handler dinoHandler =
+        context -> {
           try {
             // TODO(jkinkead): Clean this up; we should have a helper to handle this.
             Optional<Dino> d;
             d =
                 Optional.of(
                     Dino.parseFrom(
-                        CodedInputStream.newInstance(((FullHttpRequest) x).content().nioBuffer())));
+                        CodedInputStream.newInstance(
+                            ((FullHttpRequest) context).content().nioBuffer())));
             d.ifPresent(dinos::add);
           } catch (IOException e) {
             log.error("Dino Error", (Throwable) e);
@@ -150,14 +136,9 @@ public class Example {
         };
 
     // Define a simple function call
-    Function<HttpRequest, HttpResponse> healthCheckHandler =
-        x -> {
-          HttpResponse response =
-              new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-          response.headers().set(CONTENT_TYPE, "text/plain");
-          response.headers().setInt(CONTENT_LENGTH, 0);
-
-          return response;
+    Handler healthCheckHandler =
+        context -> {
+          return Recipes.newResponseOk("");
         };
 
     // Create your route mapping

--- a/src/main/java/com/nordstrom/xrpc/http/Context.java
+++ b/src/main/java/com/nordstrom/xrpc/http/Context.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.http;
+
+import io.netty.handler.codec.http.HttpRequest;
+import java.util.Map;
+import lombok.Getter;
+
+/** Request context. */
+public class Context {
+  /** The request to handle. */
+  @Getter private final HttpRequest request;
+  /** The variables captured from the route path. */
+  private final Map<String, String> groups;
+
+  public Context(HttpRequest request, Map<String, String> groups) {
+    this.request = request;
+    this.groups = groups;
+  }
+
+  /** Returns the variable with the given name, or null if that variable doesn't exist. */
+  public String variable(String name) {
+    return groups.get(name);
+  }
+}

--- a/src/main/java/com/nordstrom/xrpc/http/Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/http/Handler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.http;
+
+import io.netty.handler.codec.http.HttpResponse;
+
+import java.io.IOException;
+
+/** A handler for an HTTP route. */
+@FunctionalInterface
+public interface Handler {
+  HttpResponse handle(Context context) throws IOException;
+}

--- a/src/main/java/com/nordstrom/xrpc/http/Recipes.java
+++ b/src/main/java/com/nordstrom/xrpc/http/Recipes.java
@@ -34,10 +34,9 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.StandardCharsets;
 
+/** Container for utility methods and helpers. */
 public final class Recipes {
-  protected Recipes() {}
-
-  private static final HttpVersion v1_1 = HttpVersion.HTTP_1_1;
+  private Recipes() {}
 
   public static enum ContentType {
     Application_Json("application/json"),
@@ -94,12 +93,12 @@ public final class Recipes {
 
   // Response {{{
   public static HttpResponse newResponse(HttpResponseStatus status) {
-    return new DefaultHttpResponse(v1_1, status);
+    return new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
   }
 
   public static HttpResponse newResponse(
       HttpResponseStatus status, ByteBuf buffer, ContentType contentType) {
-    FullHttpResponse response = new DefaultFullHttpResponse(v1_1, status, buffer);
+    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, buffer);
 
     response.headers().set(CONTENT_TYPE, contentType.value);
     response.headers().setInt(CONTENT_LENGTH, buffer.readableBytes());

--- a/src/main/java/com/nordstrom/xrpc/http/Route.java
+++ b/src/main/java/com/nordstrom/xrpc/http/Route.java
@@ -17,6 +17,7 @@
 package com.nordstrom.xrpc.http;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,10 @@ public class Route {
   public Map<String, String> groups(String path) {
     Matcher matcher = pathPattern.matcher(path);
     if (matcher.matches()) {
+      if (matcher.groupCount() == 0) {
+        return Collections.emptyMap();
+      }
+
       Map<String, String> groups = new HashMap<>();
       for (String keyword : keywords) {
         groups.put(keyword, matcher.group(keyword));

--- a/src/test/java/com/nordstrom/xrpc/http/RouteTest.java
+++ b/src/test/java/com/nordstrom/xrpc/http/RouteTest.java
@@ -16,66 +16,75 @@
 
 package com.nordstrom.xrpc.http;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RouteTest {
-
   @Test
-  public void testWildcard() throws Exception {
-    Route matches1 = Route.build(".*");
+  public void testMatches_noVariables() {
+    Route route = Route.build("/api/people");
 
-    assertTrue(matches1.matches("/api/people/jeff"));
+    assertTrue(route.matches("/api/people"), "exact path match failed");
+    assertTrue(route.matches("/api/people/"), "trailing slash should be allowed");
+    assertFalse(route.matches("/api"), "subpath match should've failed");
+    assertFalse(route.matches("/api/people/jeff"), "prefix match should've failed");
   }
 
   @Test
-  public void testPathPattern() throws Exception {
+  public void testMatches_singleSimpleVariable() {
+    Route route = Route.build("/api/people/{person}");
 
-    String pathPattern1 = Route.build("/api/people/:person").pathPattern().toString();
-
-    assertEquals(pathPattern1, "/api/people/(?<person>[^/]*)[/]?");
-
-    String pathPattern2 =
-        Route.build("/api/people/:person/hands/:hand/slap").pathPattern().toString();
-
-    assertEquals(pathPattern2, "/api/people/(?<person>[^/]*)/hands/(?<hand>[^/]*)/slap[/]?");
+    assertTrue(route.matches("/api/people/jeff"), "path match failed with variable set");
+    assertTrue(route.matches("/api/people/jeff/"), "trailing slash should be allowed");
+    assertFalse(route.matches("/api/people/"), "subpath match should've failed");
+    assertFalse(route.matches("/api/people/jeff/rose"), "prefix match should've failed");
   }
 
   @Test
-  public void testMatches() throws Exception {
-    Route matches1 = Route.build("/api/people/:person");
-
-    assertTrue(matches1.matches("/api/people/jeff"));
+  public void testMatches_multipleVariables() {
+    Route route = Route.build("/api/location/{country}/{city}");
+    String path = "/api/location/usa/seattle";
+    assertTrue(route.matches(path), "failed to match path " + path);
+    assertFalse(route.matches("/api/location//seattle"), "matched empty path segment");
   }
 
   @Test
-  public void testMatchesAny() throws Exception {
-    Route matches1 = Route.build(".*");
-
-    assertTrue(matches1.matches("/api/people/jeff"));
+  public void testMatches_customPattern() {
+    Route route = Route.build("/api/person/{age:\\d+}/all");
+    String path = "/api/person/45/all";
+    assertTrue(route.matches(path), "failed to match path " + path);
+    assertFalse(route.matches("/api/person/abc/all"), "matched non-numeric path segment");
   }
 
   @Test
-  public void testGroups() throws Exception {
-
-    Map<String, String> group1 = Route.build("/api/people/:person").groups("/api/people/jeff");
-
-    assertEquals(group1.get("person"), "jeff");
-
-    Map<String, String> group2 =
-        Route.build("/api/people/:person/hands/:hand/slap")
-            .groups("/api/people/jeff/hands/left/slap");
-
-    assertEquals(group2.get("person"), "jeff");
-    assertEquals(group2.get("hand"), "left");
+  public void testMatches_patternEscaped() {
+    Route route = Route.build("/api/.*");
+    assertTrue(route.matches("/api/.*"), "failed to match exact path");
+    assertFalse(route.matches("/api/person"), "matched patterned path");
   }
 
   @Test
-  public void testCompile() throws Exception {}
+  public void testGroups_singleVariable() {
+    Route route = Route.build("/api/people/{person}");
+    Map<String, String> groups = route.groups("/api/people/jeff");
+    assertNotNull(groups, "null groups from route.groups");
+    assertEquals(1, groups.size(), "should have exactly one group");
+    assertEquals("jeff", groups.get("person"), "variable should bind correctly");
+  }
 
   @Test
-  public void testBuild() throws Exception {}
+  public void testGroups_multipleVariables() {
+    Route route = Route.build("/api/location/{country}/{city}");
+    String path = "/api/location/usa/seattle";
+    Map<String, String> groups = route.groups("/api/location/usa/seattle");
+    assertNotNull(groups, "null groups from route.groups");
+    assertEquals(2, groups.size(), "should have exactly two groups");
+    assertEquals("usa", groups.get("country"), "country variable should bind correctly");
+    assertEquals("seattle", groups.get("city"), "city variable should bind correctly");
+  }
 }


### PR DESCRIPTION
This does two things (in two commits):
- switch to gorilla-mux-variables (and fix some weird edge-cases in the original implementation)
- use a single handler class, instead of raw functions

I think this might be more interesting to @andyday , but @emmanuel has been looking at this repo as well.