### PR TITLE
Only sign release jars.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ artifacts {
 
 // Sign artifacts.
 signing {
+    // Only sign release versions.
+    required { !version.endsWith('-SNAPSHOT') }
     sign configurations.archives
 }
 


### PR DESCRIPTION
This should allow publishing local jars without needing to have pgp keys configured.