### PR TITLE
Removed XrpcChannelContext to address Issue 43

### DIFF
--- a/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -1,0 +1,11 @@
+package com.nordstrom.xrpc;
+
+import com.nordstrom.xrpc.server.XrpcConnectionContext;
+import com.nordstrom.xrpc.server.XrpcRequest;
+import io.netty.util.AttributeKey;
+
+public class XrpcConstants {
+  public static final AttributeKey<XrpcRequest> XRPC_REQUEST = AttributeKey.valueOf("XrpcRequest");
+  public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
+      AttributeKey.valueOf("XrpcConnectionContext");
+}

--- a/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
@@ -7,11 +7,8 @@ public final class Http2HandlerBuilder
     extends AbstractHttp2ConnectionHandlerBuilder<Http2Handler, Http2HandlerBuilder> {
 
   private final Http2FrameLogger logger = new Http2FrameLogger(LogLevel.INFO, Http2Handler.class);
-  private final XrpcChannelContext xctx;
 
-  public Http2HandlerBuilder(XrpcChannelContext xctx) {
-    this.xctx = xctx;
-
+  public Http2HandlerBuilder(XrpcConnectionContext xctx) {
     frameLogger(logger);
   }
 
@@ -25,7 +22,7 @@ public final class Http2HandlerBuilder
       Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
-    Http2Handler handler = new Http2Handler(xctx, decoder, encoder, initialSettings);
+    Http2Handler handler = new Http2Handler(decoder, encoder, initialSettings);
     frameListener(handler);
     return handler;
   }

--- a/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -56,7 +56,6 @@ public class Router {
   private final int bossThreadCount;
   private final int workerThreadCount;
   private final int MAX_PAYLOAD_SIZE;
-  //private static final AttributeKey<XioConnectionContext> CONNECTION_CONTEXT = AttributeKey.valueOf("XioConnectionContext")
 
   private final MetricRegistry metricRegistry = new MetricRegistry();
   final Slf4jReporter slf4jReporter =
@@ -93,7 +92,10 @@ public class Router {
     this.MAX_PAYLOAD_SIZE = maxPayload;
 
     this.ctx =
-        XrpcConnectionContext.builder().requestMeter(metricRegistry.meter("requests")).build();
+        XrpcConnectionContext.builder()
+            .requestMeter(metricRegistry.meter("requests"))
+            .maxPayloadSize(MAX_PAYLOAD_SIZE)
+            .build();
 
     configResponseCodeMeters();
   }

--- a/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -12,20 +12,20 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
+import io.netty.util.AttributeKey;
 import java.util.Map;
 import java.util.Optional;
 
 @ChannelHandler.Sharable
 public class UrlRouter extends ChannelDuplexHandler {
-  private final XrpcChannelContext xctx;
+  private static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
+      AttributeKey.valueOf("XrpcConnectionContext");
 
-  public UrlRouter(XrpcChannelContext ctx) {
-
-    this.xctx = ctx;
-  }
+  public UrlRouter() {}
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    XrpcConnectionContext xctx = ctx.channel().attr(CONNECTION_CONTEXT).get();
     xctx.getRequestMeter().mark();
 
     if (msg instanceof HttpRequest) {

--- a/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -4,6 +4,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 
 import com.google.common.collect.ImmutableMap;
+import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.client.XUrl;
 import com.nordstrom.xrpc.server.http.Route;
 import com.nordstrom.xrpc.server.http.XHttpMethod;
@@ -12,20 +13,15 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
-import io.netty.util.AttributeKey;
 import java.util.Map;
 import java.util.Optional;
 
 @ChannelHandler.Sharable
 public class UrlRouter extends ChannelDuplexHandler {
-  private static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
-      AttributeKey.valueOf("XrpcConnectionContext");
-
-  public UrlRouter() {}
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-    XrpcConnectionContext xctx = ctx.channel().attr(CONNECTION_CONTEXT).get();
+    XrpcConnectionContext xctx = ctx.channel().attr(XrpcConstants.CONNECTION_CONTEXT).get();
     xctx.getRequestMeter().mark();
 
     if (msg instanceof HttpRequest) {

--- a/src/main/java/com/nordstrom/xrpc/server/XrpcBootstrapFactory.java
+++ b/src/main/java/com/nordstrom/xrpc/server/XrpcBootstrapFactory.java
@@ -1,0 +1,72 @@
+package com.nordstrom.xrpc.server;
+
+import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
+import static io.netty.channel.ChannelOption.TCP_NODELAY;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import java.util.concurrent.ThreadFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class XrpcBootstrapFactory {
+
+  private XrpcBootstrapFactory() {};
+
+  private static ThreadFactory threadFactory(String nameFormat) {
+    return new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+  }
+
+  public static ServerBootstrap buildBootstrap(
+      int bossThreadCount, int workerThreadCount, String workerNameFormat) {
+    ServerBootstrap b = new ServerBootstrap();
+
+    EventLoopGroup bossGroup;
+    EventLoopGroup workerGroup;
+    Class<? extends ServerChannel> channelClass;
+
+    if (Epoll.isAvailable()) {
+      log.info("Using Epoll");
+      bossGroup = new EpollEventLoopGroup(bossThreadCount, threadFactory(workerNameFormat));
+      workerGroup = new EpollEventLoopGroup(workerThreadCount, threadFactory(workerNameFormat));
+      channelClass = EpollServerSocketChannel.class;
+    } else if (KQueue.isAvailable()) {
+      log.info("Using KQueue");
+      bossGroup = new KQueueEventLoopGroup(bossThreadCount, threadFactory(workerNameFormat));
+      workerGroup = new KQueueEventLoopGroup(workerThreadCount, threadFactory(workerNameFormat));
+      channelClass = KQueueServerSocketChannel.class;
+      b.option(EpollChannelOption.SO_REUSEPORT, true);
+    } else {
+      log.info("Using NIO");
+      bossGroup = new NioEventLoopGroup(bossThreadCount, threadFactory(workerNameFormat));
+      workerGroup = new NioEventLoopGroup(workerThreadCount, threadFactory(workerNameFormat));
+      channelClass = NioServerSocketChannel.class;
+    }
+
+    b.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+    b.option(ChannelOption.SO_BACKLOG, 8192);
+    b.option(ChannelOption.SO_REUSEADDR, true);
+
+    b.childOption(ChannelOption.SO_REUSEADDR, true);
+    b.childOption(SO_KEEPALIVE, true);
+    b.childOption(TCP_NODELAY, true);
+
+    b.group(bossGroup, workerGroup);
+    b.channel(channelClass);
+
+    return b;
+  }
+}

--- a/src/main/java/com/nordstrom/xrpc/server/XrpcConnectionContext.java
+++ b/src/main/java/com/nordstrom/xrpc/server/XrpcConnectionContext.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @Builder
 public class XrpcConnectionContext {
   @Getter private Meter requestMeter;
+  @Getter private int maxPayloadSize;
 
   @Getter
   private final ConcurrentHashMap<HttpResponseStatus, Meter> metersByStatusCode =

--- a/src/main/java/com/nordstrom/xrpc/server/XrpcConnectionContext.java
+++ b/src/main/java/com/nordstrom/xrpc/server/XrpcConnectionContext.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Builder
-public class XrpcChannelContext {
+public class XrpcConnectionContext {
   @Getter private Meter requestMeter;
 
   @Getter


### PR DESCRIPTION
Removed the XrpcChannelContext and added an attribute to
ctx.channel().attr() to address Issue 43 as well as remove a ~250us
regression in the code base. This commit should generate significantly less
garbage and has removed the added regression. To reproduce run

```bash
$ wrk -c 15 -d 60 -t 4 https://localhost:8080/people --latency
Running 1m test @ https://localhost:8080/people
  4 threads and 15 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   446.38us    1.26ms 136.34ms   99.03%
    Req/Sec   127.62     31.13     0.90k    99.08%
  Latency Distribution
     50%  390.00us
     75%  451.00us
     90%  548.00us
     99%    1.63ms
  30525 requests in 1.00m, 2.10MB read
```