### PR TITLE
Return 429 on too many requests and fix npe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 plugins {
   id 'com.github.sherter.google-java-format' version '0.6'
   id 'net.researchgate.release' version '2.4.0'
+  id "com.github.spotbugs" version "1.6.0"
 }
 
 release {
@@ -23,13 +24,13 @@ release {
   }
 }
 
-apply plugin: 'checkstyle'
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'checkstyle'
+
 // Junit 5 gradle runner.
 apply plugin: 'org.junit.platform.gradle.plugin'
-apply plugin: 'com.uber.infer.java'
 
 group = 'com.nordstrom.xrpc'
 archivesBaseName = 'xrpc'
@@ -66,6 +67,7 @@ dependencies {
     compile 'io.netty:netty-transport-native-kqueue:4.1.19.Final'
     compile 'org.projectlombok:lombok:1.16.16'
     compile 'org.slf4j:slf4j-api:1.7.25'
+    compile 'com.github.spotbugs:spotbugs:3.1.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
@@ -74,6 +76,10 @@ dependencies {
 // Run with the latest checkstyle version. Required for our checkstyle.xml.
 checkstyle {
   toolVersion '8.3'
+}
+
+spotbugs {
+  toolVersion = '3.1.0'
 }
 
 // Configure Maven upload.
@@ -89,6 +95,13 @@ task sourcesJar(type: Jar) {
 }
 artifacts {
     archives javadocJar, sourcesJar
+}
+
+tasks.withType(com.github.spotbugs.SpotBugsTask) {
+  reports {
+    xml.enabled = false
+    html.enabled = true
+  }
 }
 
 // Sign artifacts.

--- a/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
@@ -148,12 +148,12 @@ public class Example {
     // Health Check for k8s
     router.addRoute("/health", healthCheckHandler);
 
+    // Add a service specific health check
+    router.addHealthCheck("simple", new SimpleHealthCheck());
+
     try {
       // Fire away
-      router.addHealthCheck("simple", new SimpleHealthCheck());
-      router.serveAdmin();
       router.listenAndServe();
-      router.scheduleHealthChecks();
     } catch (IOException e) {
       log.error("Failed to start people server", e);
     }

--- a/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -35,7 +35,8 @@ public class XConfig {
   private final int bossThreadCount;
   private final int workerThreadCount;
   private final int maxConnections;
-  private final double rateLimit;
+  private final double softRateLimit;
+  private final double hardRateLimit;
   private final String cert;
   private final String key;
   private final int port;
@@ -64,7 +65,8 @@ public class XConfig {
     bossThreadCount = config.getInt("boss_thread_count");
     workerThreadCount = config.getInt("worker_thread_count");
     maxConnections = config.getInt("max_connections");
-    rateLimit = config.getDouble("req_per_sec");
+    softRateLimit = config.getDouble("soft_req_per_sec");
+    hardRateLimit = config.getDouble("hard_req_per_sec");
     cert = config.getString("cert");
     key = config.getString("key");
     port = config.getInt("server.port");
@@ -98,8 +100,12 @@ public class XConfig {
     return maxConnections;
   }
 
-  public double rateLimit() {
-    return rateLimit;
+  public double softRateLimit() {
+    return softRateLimit;
+  }
+
+  public double hardRateLimit() {
+    return hardRateLimit;
   }
 
   public String cert() {

--- a/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -35,8 +35,8 @@ public class XConfig {
   private final int bossThreadCount;
   private final int workerThreadCount;
   private final int maxConnections;
-  private final double softRateLimit;
-  private final double hardRateLimit;
+  private final double softReqPerSec;
+  private final double hardReqPerSec;
   private final String cert;
   private final String key;
   private final int port;
@@ -65,8 +65,8 @@ public class XConfig {
     bossThreadCount = config.getInt("boss_thread_count");
     workerThreadCount = config.getInt("worker_thread_count");
     maxConnections = config.getInt("max_connections");
-    softRateLimit = config.getDouble("soft_req_per_sec");
-    hardRateLimit = config.getDouble("hard_req_per_sec");
+    softReqPerSec = config.getDouble("soft_req_per_sec");
+    hardReqPerSec = config.getDouble("hard_req_per_sec");
     cert = config.getString("cert");
     key = config.getString("key");
     port = config.getInt("server.port");
@@ -100,12 +100,12 @@ public class XConfig {
     return maxConnections;
   }
 
-  public double softRateLimit() {
-    return softRateLimit;
+  public double softReqPerSec() {
+    return softReqPerSec;
   }
 
-  public double hardRateLimit() {
-    return hardRateLimit;
+  public double hardReqPerSec() {
+    return hardReqPerSec;
   }
 
   public String cert() {

--- a/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -2,6 +2,8 @@ package com.nordstrom.xrpc;
 
 import com.nordstrom.xrpc.server.XrpcConnectionContext;
 import com.nordstrom.xrpc.server.XrpcRequest;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.util.AttributeKey;
 import java.nio.charset.Charset;
 
@@ -11,4 +13,8 @@ public class XrpcConstants {
   public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
   public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+  public static final ByteBuf RATE_LIMIT_RESPONSE = Unpooled.directBuffer()
+    .writeBytes(
+      "This response is being send due to too many requests being sent to the server"
+        .getBytes(DEFAULT_CHARSET));
 }

--- a/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -6,6 +6,7 @@ import io.netty.util.AttributeKey;
 
 public class XrpcConstants {
   public static final AttributeKey<XrpcRequest> XRPC_REQUEST = AttributeKey.valueOf("XrpcRequest");
+  public static final AttributeKey<Boolean> XRPC_RATE_LIMIT = AttributeKey.valueOf("XrpcRateLimit");
   public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
 }

--- a/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -3,10 +3,12 @@ package com.nordstrom.xrpc;
 import com.nordstrom.xrpc.server.XrpcConnectionContext;
 import com.nordstrom.xrpc.server.XrpcRequest;
 import io.netty.util.AttributeKey;
+import java.nio.charset.Charset;
 
 public class XrpcConstants {
   public static final AttributeKey<XrpcRequest> XRPC_REQUEST = AttributeKey.valueOf("XrpcRequest");
   public static final AttributeKey<Boolean> XRPC_RATE_LIMIT = AttributeKey.valueOf("XrpcRateLimit");
   public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
+  public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
 }

--- a/src/main/java/com/nordstrom/xrpc/server/ConnectionLimiter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/ConnectionLimiter.java
@@ -27,10 +27,10 @@ public class ConnectionLimiter extends ChannelDuplexHandler {
   public void channelActive(ChannelHandlerContext ctx) throws Exception {
     connections.inc();
 
+    //TODO(JR): Should this return a 429 or is the current logic of silently dropping the connection sufficient?
     if (maxConnections > 0) {
       if (numConnections.incrementAndGet() > maxConnections) {
         ctx.channel().close();
-        // numConnections will be decremented in channelClosed
         log.info("Accepted connection above limit (" + maxConnections + "). Dropping.");
       }
     }

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -162,7 +162,6 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
       int padding,
       boolean endOfStream) {
 
-    // This object is being called without an Optional<Boolean> to limit object creation and thus reduce GC pressure
     if (ctx.channel().hasAttr(XrpcConstants.XRPC_RATE_LIMIT)) {
       writeResponse(
           ctx,

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -145,7 +145,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
             log.error("Error in handling Route", e);
             // Error
             ByteBuf buf = ctx.channel().alloc().directBuffer();
-            buf.writeBytes("Error executing endpoint".getBytes());
+            buf.writeBytes("Error executing endpoint".getBytes(XrpcConstants.DEFAULT_CHARSET));
             writeResponse(ctx, streamId, HttpResponseStatus.INTERNAL_SERVER_ERROR, buf);
           }
         }
@@ -163,7 +163,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
       boolean endOfStream) {
 
     // This object is being called without an Optional<Boolean> to limit object creation and thus reduce GC pressure
-    if (ctx.channel().attr(XrpcConstants.XRPC_RATE_LIMIT).get() != null) {
+    if (ctx.channel().hasAttr(XrpcConstants.XRPC_RATE_LIMIT)) {
       writeResponse(
           ctx,
           streamId,
@@ -172,7 +172,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
               .directBuffer()
               .writeBytes(
                   "This respone is being send due to too many requests being sent to the server"
-                      .getBytes()));
+                      .getBytes(XrpcConstants.DEFAULT_CHARSET)));
       return;
     }
 
@@ -198,7 +198,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
             log.error("Error in handling Route", e);
             // Error
             ByteBuf buf = ctx.channel().alloc().directBuffer();
-            buf.writeBytes("Error executing endpoint".getBytes());
+            buf.writeBytes("Error executing endpoint".getBytes(XrpcConstants.DEFAULT_CHARSET));
             writeResponse(ctx, streamId, HttpResponseStatus.INTERNAL_SERVER_ERROR, buf);
           }
         }
@@ -206,7 +206,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
     }
     // No Valid Route
     ByteBuf buf = ctx.channel().alloc().directBuffer();
-    buf.writeBytes("Endpoint not found".getBytes());
+    buf.writeBytes("Endpoint not found".getBytes(XrpcConstants.DEFAULT_CHARSET));
     writeResponse(ctx, streamId, HttpResponseStatus.NOT_FOUND, buf);
   }
 

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -167,11 +167,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
           ctx,
           streamId,
           HttpResponseStatus.TOO_MANY_REQUESTS,
-          ctx.alloc()
-              .directBuffer()
-              .writeBytes(
-                  "This respone is being send due to too many requests being sent to the server"
-                      .getBytes(XrpcConstants.DEFAULT_CHARSET)));
+          XrpcConstants.RATE_LIMIT_RESPONSE);
       return;
     }
 

--- a/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -16,7 +16,10 @@
 
 package com.nordstrom.xrpc.server;
 
-import com.codahale.metrics.*;
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.json.MetricsModule;
@@ -56,8 +59,11 @@ public class Router {
   private final int bossThreadCount;
   private final int workerThreadCount;
   private final int MAX_PAYLOAD_SIZE;
+  private final Tls tls;
+  private final XrpcConnectionContext ctx;
 
   private final MetricRegistry metricRegistry = new MetricRegistry();
+
   final Slf4jReporter slf4jReporter =
       Slf4jReporter.forRegistry(metricRegistry)
           .outputTo(LoggerFactory.getLogger(Router.class))
@@ -65,19 +71,15 @@ public class Router {
           .convertDurationsTo(TimeUnit.MILLISECONDS)
           .build();
   final JmxReporter jmxReporter = JmxReporter.forRegistry(metricRegistry).build();
-  private final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry(this.workerGroup);
   private final ConsoleReporter consoleReporter =
       ConsoleReporter.forRegistry(metricRegistry)
           .convertRatesTo(TimeUnit.SECONDS)
           .convertDurationsTo(TimeUnit.MILLISECONDS)
           .build();
-  private final Tls tls;
-  @Getter private Channel channel;
-  private EventLoopGroup bossGroup;
-  @Getter private EventLoopGroup workerGroup;
-  private Class<? extends ServerChannel> channelClass;
 
-  private final XrpcConnectionContext ctx;
+  @Getter private Channel channel;
+  @Getter private HealthCheckRegistry healthCheckRegistry;
+  private final Map<String, HealthCheck> healthCheckMap = new ConcurrentHashMap<>();
 
   public Router(XConfig config) {
     this(config, 1 * 1024 * 1024);
@@ -111,6 +113,8 @@ public class Router {
     meterNamesByStatusCode.put(HttpResponseStatus.BAD_REQUEST, NAME_PREFIX + "badRequest");
     meterNamesByStatusCode.put(HttpResponseStatus.NOT_FOUND, NAME_PREFIX + "notFound");
     meterNamesByStatusCode.put(
+        HttpResponseStatus.TOO_MANY_REQUESTS, NAME_PREFIX + "tooManyRequests");
+    meterNamesByStatusCode.put(
         HttpResponseStatus.INTERNAL_SERVER_ERROR, NAME_PREFIX + "serverError");
 
     for (Map.Entry<HttpResponseStatus, String> entry : meterNamesByStatusCode.entrySet()) {
@@ -119,14 +123,23 @@ public class Router {
   }
 
   public void addHealthCheck(String s, HealthCheck check) {
-    healthCheckRegistry.register(s, check);
+    Preconditions.checkState(
+        !healthCheckMap.containsKey(s), "A Health Check by that name has already been registered");
+    healthCheckMap.put(s, check);
   }
 
-  public void scheduleHealthChecks() {
-    scheduleHealthChecks(60, 60, TimeUnit.SECONDS);
+  public void scheduleHealthChecks(EventLoopGroup workerGroup) {
+    scheduleHealthChecks(workerGroup, 60, 60, TimeUnit.SECONDS);
   }
 
-  public void scheduleHealthChecks(int initialDelay, int delay, TimeUnit timeUnit) {
+  public void scheduleHealthChecks(
+      EventLoopGroup workerGroup, int initialDelay, int delay, TimeUnit timeUnit) {
+    healthCheckRegistry = new HealthCheckRegistry(workerGroup);
+
+    for (String check : healthCheckMap.keySet()) {
+      healthCheckRegistry.register(check, healthCheckMap.get(check));
+    }
+
     workerGroup.scheduleWithFixedDelay(
         new Runnable() {
           @Override
@@ -139,13 +152,14 @@ public class Router {
         timeUnit);
   }
 
-  public void addRoute(String s, Handler handler) {
-    addRoute(s, handler, XHttpMethod.ANY);
+  public void addRoute(String route, Handler handler) {
+    addRoute(route, handler, XHttpMethod.ANY);
   }
 
   public void addRoute(String route, Handler handler, HttpMethod method) {
-    Preconditions.checkState(method != null);
+    Preconditions.checkState(!route.isEmpty());
     Preconditions.checkState(handler != null);
+    Preconditions.checkState(method != null);
 
     ImmutableMap<XHttpMethod, Handler> handlerMap =
         new ImmutableMap.Builder<XHttpMethod, Handler>()
@@ -210,13 +224,18 @@ public class Router {
   }
 
   public void listenAndServe() throws IOException {
+    listenAndServe(true, true);
+  }
+
+  public void listenAndServe(boolean serveAdmin, boolean scheduleHealthChecks) throws IOException {
     ConnectionLimiter globalConnectionLimiter =
         new ConnectionLimiter(
             metricRegistry, config.maxConnections()); // All endpoints for a given service
     ServiceRateLimiter rateLimiter =
         new ServiceRateLimiter(
             metricRegistry,
-            config.rateLimit()); // RateLimit incomming connections in terms of req / second
+            config.softRateLimit(),
+            config.hardRateLimit()); // RateLimit incomming connections in terms of req / second
 
     ServerBootstrap b =
         XrpcBootstrapFactory.buildBootstrap(bossThreadCount, workerThreadCount, workerNameFormat);
@@ -244,6 +263,14 @@ public class Router {
           }
         });
 
+    if (scheduleHealthChecks) {
+      scheduleHealthChecks(b.config().childGroup());
+    }
+
+    if (serveAdmin) {
+      serveAdmin();
+    }
+
     ChannelFuture future = b.bind(new InetSocketAddress(config.port()));
 
     try {
@@ -254,6 +281,7 @@ public class Router {
       jmxReporter.start();
 
       future.await();
+
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted waiting for bind");

--- a/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -231,9 +231,9 @@ public class Router {
    * The listenAndServe method is the primary entry point for the server and should only be called
    * once and only from the main thread.
    *
-   * @param serveAdmin
-   * @param scheduleHealthChecks
-   * @throws IOException
+   * @param serveAdmin pass true to serve the admin handlers, false if not
+   * @param scheduleHealthChecks pass true to schedule periodic health checks, otherwise, the health checks will be run every time the health endpoint is hit
+   * @throws IOException throws in the event the network services, as specified, cannot be accessed
    */
   public void listenAndServe(boolean serveAdmin, boolean scheduleHealthChecks) throws IOException {
     ConnectionLimiter globalConnectionLimiter =

--- a/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
@@ -35,7 +35,7 @@ public class ServiceRateLimiter extends ChannelDuplexHandler {
     hardLimiter.acquire();
 
     if (!softLimiter.tryAcquire()) {
-      ctx.channel().attr(XrpcConstants.XRPC_RATE_LIMIT).set(true);
+      ctx.channel().attr(XrpcConstants.XRPC_RATE_LIMIT).set(Boolean.TRUE);
     }
 
     context = timer.time();

--- a/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -28,7 +28,7 @@ public class UrlRouter extends ChannelDuplexHandler {
     xctx.getRequestMeter().mark();
 
     // This object is being called without an Optional<Boolean> to limit object creation and thus reduce GC pressure
-    if (ctx.channel().attr(XrpcConstants.XRPC_RATE_LIMIT).get() != null) {
+    if (ctx.channel().hasAttr(XrpcConstants.XRPC_RATE_LIMIT)) {
       ctx.writeAndFlush(
               Recipes.newResponse(
                   HttpResponseStatus.TOO_MANY_REQUESTS,
@@ -36,7 +36,7 @@ public class UrlRouter extends ChannelDuplexHandler {
                       .directBuffer()
                       .writeBytes(
                           "This respone is being send due to too many requests being sent to the server"
-                              .getBytes()),
+                              .getBytes(XrpcConstants.DEFAULT_CHARSET)),
                   Recipes.ContentType.Text_Plain))
           .addListener(ChannelFutureListener.CLOSE);
       xctx.getMetersByStatusCode().get(HttpResponseStatus.TOO_MANY_REQUESTS).mark();

--- a/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -9,6 +9,9 @@ import com.nordstrom.xrpc.client.XUrl;
 import com.nordstrom.xrpc.server.http.Recipes;
 import com.nordstrom.xrpc.server.http.Route;
 import com.nordstrom.xrpc.server.http.XHttpMethod;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledDirectByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -30,12 +33,7 @@ public class UrlRouter extends ChannelDuplexHandler {
     if (ctx.channel().hasAttr(XrpcConstants.XRPC_RATE_LIMIT)) {
       ctx.writeAndFlush(
               Recipes.newResponse(
-                  HttpResponseStatus.TOO_MANY_REQUESTS,
-                  ctx.alloc()
-                      .directBuffer()
-                      .writeBytes(
-                          "This respone is being send due to too many requests being sent to the server"
-                              .getBytes(XrpcConstants.DEFAULT_CHARSET)),
+                  HttpResponseStatus.TOO_MANY_REQUESTS, XrpcConstants.RATE_LIMIT_RESPONSE,
                   Recipes.ContentType.Text_Plain))
           .addListener(ChannelFutureListener.CLOSE);
       xctx.getMetersByStatusCode().get(HttpResponseStatus.TOO_MANY_REQUESTS).mark();

--- a/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -27,7 +27,6 @@ public class UrlRouter extends ChannelDuplexHandler {
     XrpcConnectionContext xctx = ctx.channel().attr(XrpcConstants.CONNECTION_CONTEXT).get();
     xctx.getRequestMeter().mark();
 
-    // This object is being called without an Optional<Boolean> to limit object creation and thus reduce GC pressure
     if (ctx.channel().hasAttr(XrpcConstants.XRPC_RATE_LIMIT)) {
       ctx.writeAndFlush(
               Recipes.newResponse(

--- a/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
+++ b/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
@@ -16,6 +16,7 @@
 
 package com.nordstrom.xrpc.server.tls;
 
+import com.nordstrom.xrpc.XrpcConstants;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
@@ -102,7 +103,7 @@ public class Tls {
           java.security.cert.X509Certificate x509Certificate =
               (java.security.cert.X509Certificate)
                   cf.generateCertificate(
-                      new ByteArrayInputStream((cert + "-----END CERTIFICATE-----\n").getBytes()));
+                      new ByteArrayInputStream((cert + "-----END CERTIFICATE-----\n").getBytes(XrpcConstants.DEFAULT_CHARSET)));
           certList.add(x509Certificate);
         }
 

--- a/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -25,7 +25,10 @@ worker_thread_count = 40
 max_connections = 500
 # The maximum number of requests per second to allow before limiting new connection.
 # See: http://google.github.io/guava/releases/23.0/api/docs/com/google/common/util/concurrent/RateLimiter.html
-req_per_sec = 500.0
+# Once the soft limit is hit, the server will return a HTTP 429 TOO MANY REQUESTS
+# If the hard limit is reached, the system will block to protect the back end resources
+soft_req_per_sec = 500.0
+hard_req_per_sec = 550.0
 
 # The raw X509 certificate to use for TLS.
 cert = """


### PR DESCRIPTION
This commit addresses issues 45 and 50.

For Issue 45:
2 new limits were added to the config, a "soft" limit and a "hard" limit.
Once the soft limit is reached, the server will return 429s directly. If the
hard limit is reached, the server will block on the worker thread to protect
the back end from being overwhelmed and thus leading to resource exhaustion.

For Issue 50:
The healthCheckRegistry was be scheduled to run prior to the worker group
being properly bootstrapped. This commit changes the order in which those
processes are run. This was added to this commit for convenience.