### PR TITLE
issue 48 - query params in path variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
+    testCompile 'org.mockito:mockito-core:2.13.0'
 }
 
 // Run with the latest checkstyle version. Required for our checkstyle.xml.

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ dependencies {
     compile 'com.github.spotbugs:spotbugs:3.1.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
     testCompile 'org.mockito:mockito-core:2.13.0'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
 }
 
 // Run with the latest checkstyle version. Required for our checkstyle.xml.

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -207,7 +207,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
     writeResponse(ctx, streamId, HttpResponseStatus.NOT_FOUND, buf);
   }
 
-  protected String getPathFromHeaders (Http2Headers headers) {
+  static String getPathFromHeaders (Http2Headers headers) {
     String uri = headers.path().toString();
     return XUrl.getPath(uri);
   }

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -163,8 +163,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
       int padding,
       boolean endOfStream) {
 
-    String uri = headers.path().toString();
-    String path = XUrl.getPath(uri);
+    String path = getPathFromHeaders(headers);
 
     for (Route route :
         ctx.channel()
@@ -197,6 +196,11 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
     ByteBuf buf = ctx.channel().alloc().directBuffer();
     buf.writeBytes("Endpoint not found".getBytes());
     writeResponse(ctx, streamId, HttpResponseStatus.NOT_FOUND, buf);
+  }
+
+  protected String getPathFromHeaders (Http2Headers headers) {
+    String uri = headers.path().toString();
+    return XUrl.getPath(uri);
   }
 
   @Override

--- a/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -5,6 +5,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 
 import com.google.common.collect.ImmutableMap;
 import com.nordstrom.xrpc.XrpcConstants;
+import com.nordstrom.xrpc.client.XUrl;
 import com.nordstrom.xrpc.server.http.Route;
 import com.nordstrom.xrpc.server.http.XHttpMethod;
 import io.netty.buffer.ByteBuf;
@@ -163,6 +164,8 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
       boolean endOfStream) {
 
     String uri = headers.path().toString();
+    String path = XUrl.getPath(uri);
+
     for (Route route :
         ctx.channel()
             .attr(XrpcConstants.CONNECTION_CONTEXT)
@@ -170,7 +173,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
             .getRoutes()
             .get()
             .descendingKeySet()) {
-      Optional<Map<String, String>> groups = Optional.ofNullable(route.groups(uri));
+      Optional<Map<String, String>> groups = Optional.ofNullable(route.groups(path));
       if (groups.isPresent()) {
         ctx.channel()
             .attr(XrpcConstants.XRPC_REQUEST)

--- a/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
+++ b/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
@@ -13,13 +13,21 @@ import org.junit.jupiter.api.Test;
 
 public class Http2HandlerTest {
   @Test
-  public void getPathFromHeaders () {
+  public void getPathFromHeaders_withQueryString () {
     Http2Headers mockHeaders = mock(Http2Headers.class);
     when(mockHeaders.path()).thenReturn("/foo/extracted?query1=abc&query2=123");
 
-    Http2Handler testHandler = new Http2Handler(mock(Http2ConnectionDecoder.class), mock(Http2ConnectionEncoder.class), new Http2Settings());
+    String path = Http2Handler.getPathFromHeaders(mockHeaders);
 
-    String path = testHandler.getPathFromHeaders(mockHeaders);
+    assertEquals("/foo/extracted", path);
+  }
+
+  @Test
+  public void getPathFromHeaders_withNoQueryString () {
+    Http2Headers mockHeaders = mock(Http2Headers.class);
+    when(mockHeaders.path()).thenReturn("/foo/extracted");
+
+    String path = Http2Handler.getPathFromHeaders(mockHeaders);
 
     assertEquals("/foo/extracted", path);
   }

--- a/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
+++ b/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
@@ -1,0 +1,26 @@
+package com.nordstrom.xrpc.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Settings;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+
+
+public class Http2HandlerTest {
+  @Test
+  public void getPathFromHeaders () {
+    Http2Headers mockHeaders = mock(Http2Headers.class);
+    when(mockHeaders.path()).thenReturn("/foo/extracted?query1=abc&query2=123");
+
+    Http2Handler testHandler = new Http2Handler(mock(Http2ConnectionDecoder.class), mock(Http2ConnectionEncoder.class), new Http2Settings());
+
+    String path = testHandler.getPathFromHeaders(mockHeaders);
+
+    assertEquals("/foo/extracted", path);
+  }
+}


### PR DESCRIPTION
https://github.com/Nordstrom/xrpc/issues/48

The previous fix for this problem (https://github.com/Nordstrom/xrpc/issues/27) left http2 unresolved. This takes applies the same solution to http2 as was used for http1.