### PR TITLE
Migrate releases to bintray.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,54 +4,37 @@ For people contributing to this project.
 
 ## Publishing
 
-xrpc is published to [the central repository](https://oss.sonatype.org/#nexus-search;quick~com.nordstrom.xrpc).
+xrpc is published to [jCenter via Bintray](https://bintray.com/nordstromoss/oss_maven/xrpc).
 
 ### Setup
 
-1. [Create a Sontatype JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa), if you don't have one. This will be what you log in to the central repository with.
-2. Get added to the nordstrom.com group. This means contacting one of the administrators of the group, and filing a ticket, as described in [this issue](https://issues.sonatype.org/browse/OSSRH-13276).
-3. Create a gpg key, if you don't already have one. [This help article](http://central.sonatype.org/pages/working-with-pgp-signatures.html) has detailed instructions.
-4. If you used gpg v2.1 or greater, create a gradle-compatible old-style private keyring:
-
-    ```bash
-    touch ~/.gnupg/secring.gpg
-    chmod 600 ~/.gnupg/secring.gpg
-    gpg --export-secret-keys > ~/.gnupg/secring.gpg
-    ```
-
-5. If you haven't configured gradle to use this key yet, note the four-byte ID of your key:
-
-    ```bash
-    $ gpg --keyid-format SHORT -k {PUBLIC_KEY_ID}
-    pub   rsa2048/{FOUR_BYTES_HEX} 2017-01-01 [SC] [expires: 2019-01-01]
-          1234567890ABCDEF1234567890ABCDEF12345678
-    uid         [ultimate] Your Name <your.name@email.com>
-    sub   rsa2048/IGNORED 2017-01-01 [E] [expires: 2019-01-01]
-    ```
-
-    The string where `{FOUR_BYTES_HEX}` is above should be your four-byte key ID. The public ID of your key can be shown bu running `gpg --list-keys`.
-6. Create a private `gradle.properties` file:
+1. [Create a bintray account](https://bintray.com), if you don't have one. It's recommended that you
+   use github OAuth to create the account.
+2. Get added to the [NordstromOSS organization](https://bintray.com/nordstromoss). Any admin should
+   be able to add you to the organization if you send them your username.
+3. Create a private `gradle.properties` file:
 
     ```bash
     mkdir -p ~/.gradle
     touch ~/.gradle/gradle.properties
     chmod 600 ~/.gradle/gradle.properties
     ```
-7. If you haven't configured the gradle plugin for signing, follow [these instructions](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials). Use the four-byte value from step 5 for `keyId`, and set `secretKeyRingFile` to the full path to `~/.gnupg/secring.gpg`.
-8. If you haven't configured the gradle plugin for signing, add your JIRA credentials to `gradle.properties`:
+4. Find your bintray key in the ["Edit Profile" screen](https://bintray.com/profile/edit), under the
+   "API Key" tab on the left.
+5. Add your bintray username and key to the private `gradle.properties` file:
 
     ```
-    ossrhUsername={username}
-    ossrhPassword={password}
+    bintrayUsername={username}
+    bintrayKey={API key}
     ```
 
 ### Publishing Steps
 
 xrpc uses [gradle-release](https://github.com/researchgate/gradle-release) for publishing jars to
-Maven Central.
+Bintray.
 
-In order to use the plugin, you **must** have write permissions on this repository in GitHub. It
-will automatically push commits & the release tag to the repository.
+In order to use the plugin, you **must** have write permissions on the xrpc repository in GitHub.
+The release process will automatically push commits & the release tag to the repository.
 
 To publish:
 
@@ -59,5 +42,4 @@ To publish:
    `upstream`.
 2. Check out a branch called `master`, synced to `upstream/master`.
 3. Run `./gradlew release`. Watch the output closely for prompts, and follow instructions.
-4. Follow the [release instructions at Sonatype](http://central.sonatype.org/pages/releasing-the-deployment.html).
-5. Edit the [release notes for the tag](https://github.com/Nordstrom/xrpc/releases), and mark it as released.
+4. Edit the [release notes for the tag](https://github.com/Nordstrom/xrpc/releases), and mark it as released.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ buildscript {
 plugins {
   id 'com.github.sherter.google-java-format' version '0.6'
   id 'net.researchgate.release' version '2.4.0'
-  id "com.github.spotbugs" version "1.6.0"
+  id 'com.github.spotbugs' version '1.6.0'
+  id 'com.jfrog.bintray' version '1.7.3'
 }
 
 release {
@@ -25,7 +26,7 @@ release {
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'signing'
+apply plugin: 'maven-publish'
 apply plugin: 'checkstyle'
 
 // Junit 5 gradle runner.
@@ -82,21 +83,6 @@ spotbugs {
   ignoreFailures = true
 }
 
-// Configure Maven upload.
-
-// Add Javadoc + sources jars.
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-artifacts {
-    archives javadocJar, sourcesJar
-}
-
 tasks.withType(com.github.spotbugs.SpotBugsTask) {
   extraArgs = ['-html:fancy-hist.xsl']
   reports {
@@ -105,72 +91,81 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
   }
 }
 
-// Sign artifacts.
-signing {
-    // Only sign release versions.
-    required { !version.endsWith('-SNAPSHOT') }
-    sign configurations.archives
+// Add Javadoc + sources jars to artifacts list.
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+def pomExtra = {
+  scm {
+    connection 'scm:git:git@github.com:Nordstrom/xrpc.git'
+      developerConnection 'scm:git:git@github.com:Nordstrom/xrpc.git'
+      url 'https://github.com/Nordstrom/xrpc'
+  }
 
-      // Safe aliases for username & password that don't require them to be set in order to load the
-      // project.
-      def ossrhUsername = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : ''
-      def ossrhPassword = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : ''
+  licenses {
+    license {
+      name 'The Apache License, Version 2.0'
+        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    }
+  }
 
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
-      }
+  developers {
+    developer {
+      id 'jkinkead'
+        name 'Jesse Kinkead'
+        email 'jesse.kinkead@nordstrom.com'
+    }
+    developer {
+      id 'xjdr'
+        name 'Jeff Rose'
+        email 'jeff.rose@nordstrom.com'
+    }
+  }
+}
 
-      // Snapshots by default publish local. If you want to publish to Sonatype, use the
-      // commented-out configuration below. Note that you won't be able to resolve snapshots in
-      // other projects unless you add the repository to the appropriate configuration block.
-      //
-      // snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-      //   authentication(userName: ossrhUsername, password: ossrhPassword)
-      // }
-      snapshotRepository(url: mavenLocal().url)
+publishing {
+  publications {
+    xrpcMaven(MavenPublication) {
+      from components.java
+      groupId rootProject.group
+      artifactId rootProject.archivesBaseName
+      version rootProject.version
+      artifact sourcesJar
+      artifact javadocJar
 
-      pom.project {
-        name 'xrpc library'
-        packaging 'jar'
-        // Optionally artifactId can be defined here, instead of relying on archivesBaseName.
-        description 'Simple, production ready Java API server built on top of functional composition.'
-        url 'https://github.com/Nordstrom/xrpc'
-
-        scm {
-          connection 'scm:git:git@github.com:Nordstrom/xrpc.git'
-          developerConnection 'scm:git:git@github.com:Nordstrom/xrpc.git'
-          url 'https://github.com/Nordstrom/xrpc'
-        }
-
-        licenses {
-          license {
-            name 'The Apache License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-          }
-        }
-
-        developers {
-          developer {
-            id 'jkinkead'
-            name 'Jesse Kinkead'
-            email 'jesse.kinkead@nordstrom.com'
-          }
-          developer {
-            id 'xjdr'
-            name 'Jeff Rose'
-            email 'jeff.rose@nordstrom.com'
-          }
-        }
+      pom.withXml {
+        asNode().appendNode('description', rootProject.description)
+        asNode().appendNode('name', 'xrpc library')
+        asNode().appendNode('url', 'https://github.com/Nordstrom/xrpc')
+        asNode().children().last() + pomExtra
       }
     }
   }
 }
 
+bintray {
+  user = rootProject.hasProperty('bintrayUsername') ? rootProject.bintrayUsername : ''
+  key = rootProject.hasProperty('bintrayKey') ? rootProject.bintrayKey : ''
+  publications = ['xrpcMaven']
+  // Automatically publish the version (make it public).
+  publish = true
+  pkg {
+    userOrg = 'nordstromoss'
+    repo = 'oss_maven'
+    name = rootProject.archivesBaseName
+    licenses = ['Apache-2.0']
+    vcsUrl = 'https://github.com/Nordstrom/xrpc.git'
+    version {
+      name = rootProject.version
+    }
+  }
+}
+
 // Run the upload as a part of the "release" task.
-afterReleaseBuild.dependsOn uploadArchives
+afterReleaseBuild.dependsOn bintrayUpload

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.1.4
+version=0.1.5


### PR DESCRIPTION
I also bumped the version to `0.1.5`, because that got missed during the last release.