### PR TITLE
Add helpers to fetch request data and request headers.

### DIFF
--- a/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
+++ b/demo/src/main/java/com/nordstrom/xrpc/demo/Example.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.health.HealthCheck;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.nordstrom.xrpc.XConfig;
-import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.demo.proto.*;
 import com.nordstrom.xrpc.server.Handler;
 import com.nordstrom.xrpc.server.Router;
@@ -77,9 +76,7 @@ public class Example {
     // Define a complex function call
     Handler personPostHandler =
         request -> {
-          byte[] postData = new byte[request.getData().readableBytes()];
-          request.getData().readBytes(postData, 0, request.getData().readableBytes());
-          Person p = new Person(new String(postData, XrpcConstants.DEFAULT_CHARSET));
+          Person p = new Person(request.getDataAsString());
           people.add(p);
 
           return Recipes.newResponseOk("");


### PR DESCRIPTION
This is mostly in response to some silly boilerplate @forplayplay was needing to write.

This also decodes request bodies correctly, using any specified charset with the correct default, instead of always using UTF-8.