### PR TITLE
Break out server initializer

### DIFF
--- a/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -37,8 +37,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;

--- a/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.nordstrom.xrpc.XConfig;
-import com.nordstrom.xrpc.logging.ExceptionLogger;
 import com.nordstrom.xrpc.server.http.Route;
 import com.nordstrom.xrpc.server.http.XHttpMethod;
 import com.nordstrom.xrpc.server.tls.Tls;
@@ -297,32 +296,15 @@ public class Router {
     Http2OrHttpHandler h1h2 = new Http2OrHttpHandler(router, ctx);
 
     b.childHandler(
-        new ChannelInitializer<Channel>() {
-          @Override
-          public void initChannel(Channel ch) throws Exception {
-            ChannelPipeline cp = ch.pipeline();
-            cp.addLast(
-                "idleDisconnectHandler",
-                new IdleDisconnectHandler(
-                    config.readerIdleTimeout(),
-                    config.writerIdleTimeout(),
-                    config.allIdleTimeout()));
-            cp.addLast("serverConnectionLimiter", globalConnectionLimiter);
-            cp.addLast("serverRateLimiter", rateLimiter);
-
-            if (config.enableWhiteList()) {
-              cp.addLast("whiteList", whiteListFilter);
-            } else if (config.enableBlackList()) {
-              cp.addLast("blackList", blackListFilter);
-            }
-
-            cp.addLast("firewall", firewall);
-            cp.addLast(
-                "encryptionHandler", tls.getEncryptionHandler(ch.alloc())); // Add Config for Certs
-            cp.addLast("codec", h1h2);
-            cp.addLast("exceptionLogger", new ExceptionLogger());
-          }
-        });
+        new ServerChannelInitializer(
+            config,
+            globalConnectionLimiter,
+            rateLimiter,
+            whiteListFilter,
+            blackListFilter,
+            firewall,
+            tls,
+            h1h2));
 
     if (scheduleHealthChecks) {
       final EventLoopGroup _workerGroup = b.config().childGroup();

--- a/src/main/java/com/nordstrom/xrpc/server/ServerChannelInitializer.java
+++ b/src/main/java/com/nordstrom/xrpc/server/ServerChannelInitializer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.server;
+
+import com.nordstrom.xrpc.XConfig;
+import com.nordstrom.xrpc.logging.ExceptionLogger;
+import com.nordstrom.xrpc.server.tls.Tls;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ServerChannelInitializer sets up the ChannelPipeline for an xrpc Server. This class should be
+ * extended if you need to customize the pipeline for your Server.
+ */
+@Slf4j
+public class ServerChannelInitializer extends ChannelInitializer<Channel> {
+  private final XConfig config;
+  private final ConnectionLimiter globalConnectionLimiter;
+  private final ServiceRateLimiter rateLimiter;
+  private final WhiteListFilter whiteListFilter;
+  private final BlackListFilter blackListFilter;
+  private final Firewall firewall;
+  private final Tls tls;
+  private final Http2OrHttpHandler h1h2;
+
+  public ServerChannelInitializer(
+      XConfig config,
+      ConnectionLimiter globalConnectionLimiter,
+      ServiceRateLimiter rateLimiter,
+      WhiteListFilter whiteListFilter,
+      BlackListFilter blackListFilter,
+      Firewall firewall,
+      Tls tls,
+      Http2OrHttpHandler h1h2) {
+    this.config = config;
+    this.globalConnectionLimiter = globalConnectionLimiter;
+    this.rateLimiter = rateLimiter;
+    this.whiteListFilter = whiteListFilter;
+    this.blackListFilter = blackListFilter;
+    this.firewall = firewall;
+    this.tls = tls;
+    this.h1h2 = h1h2;
+  }
+
+  @Override
+  public void initChannel(Channel ch) throws Exception {
+    ChannelPipeline cp = ch.pipeline();
+    cp.addLast(
+        "idleDisconnectHandler",
+        new IdleDisconnectHandler(
+            config.readerIdleTimeout(), config.writerIdleTimeout(), config.allIdleTimeout()));
+    cp.addLast("serverConnectionLimiter", globalConnectionLimiter);
+    cp.addLast("serverRateLimiter", rateLimiter);
+
+    if (config.enableWhiteList()) {
+      cp.addLast("whiteList", whiteListFilter);
+    } else if (config.enableBlackList()) {
+      cp.addLast("blackList", blackListFilter);
+    }
+
+    cp.addLast("firewall", firewall);
+    cp.addLast("encryptionHandler", tls.getEncryptionHandler(ch.alloc())); // Add Config for Certs
+    cp.addLast("codec", h1h2);
+    cp.addLast("exceptionLogger", new ExceptionLogger());
+  }
+}


### PR DESCRIPTION
The `Router` class has [a lot of functionality in it](https://en.wikipedia.org/wiki/God_object). This PR breaks out the embedded `ChannelInitializer` into the `ServerChannelInitializer` class.