### PR TITLE
Add and fix compiler warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,11 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
     // The tls package uses a ton of proprietary APIs that generate warnings. Suppress these (and fork
     // the compiler so that the definition works).
-    options.compilerArgs += ['-XDignore.symbol.file']
+    options.compilerArgs += [
+        '-XDignore.symbol.file',
+        '-Xlint:auxiliaryclass,cast,classfile,deprecation,dep-ann,divzero,empty,fallthrough,' +
+            'finally,options,overloads,overrides,path,rawtypes,static,try,unchecked,varargs',
+        '-Werror']
     options.fork = true
     options.forkOptions.executable = 'javac'
 }

--- a/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
+++ b/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
@@ -21,7 +21,7 @@ public class RendezvousHash<N> {
   private final Map<Long, N> hashMap = new ConcurrentSkipListMap<>();
   private final Set<N> nodeList = Sets.newConcurrentHashSet();
 
-  public RendezvousHash(Funnel<N> nodeFunnel, Collection<N> init) {
+  public RendezvousHash(Funnel<N> nodeFunnel, Collection<? extends N> init) {
     this.hasher = Hashing.murmur3_128();
     this.nodeFunnel = nodeFunnel;
 

--- a/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -139,7 +139,7 @@ public class XConfig {
             xs.forEach(
                 (key, value) -> {
                   List<String> valString = Arrays.asList(value.unwrapped().toString().split(":"));
-                  List<Double> val = new ArrayList();
+                  List<Double> val = new ArrayList<>();
                   valString.forEach(v -> val.add(Double.parseDouble(v)));
 
                   clientRateLimitOverride.put(key, val);

--- a/src/main/java/com/nordstrom/xrpc/client/Call.java
+++ b/src/main/java/com/nordstrom/xrpc/client/Call.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.nordstrom.xrpc.client.retry.BoundedExponentialBackoffRetry;
 import com.nordstrom.xrpc.client.retry.RetryLoop;
@@ -91,7 +92,9 @@ public class Call {
             response.cancel(true);
             error.setException(t);
           }
-        });
+        },
+        MoreExecutors.directExecutor()
+        );
 
     if (response.isCancelled()) {
       return error;

--- a/src/main/java/com/nordstrom/xrpc/client/Call.java
+++ b/src/main/java/com/nordstrom/xrpc/client/Call.java
@@ -93,8 +93,7 @@ public class Call {
             error.setException(t);
           }
         },
-        MoreExecutors.directExecutor()
-        );
+        MoreExecutors.directExecutor());
 
     if (response.isCancelled()) {
       return error;

--- a/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
@@ -29,8 +29,8 @@ class ServiceRateLimiter extends ChannelDuplexHandler {
   private final Meter reqs;
   private final Timer timer;
   private final XConfig config;
-  private final RendezvousHash softRateLimitHasher;
-  private final RendezvousHash hardRateLimitHasher;
+  private final RendezvousHash<CharSequence> softRateLimitHasher;
+  private final RendezvousHash<CharSequence> hardRateLimitHasher;
   private final RateLimiter globalHardLimiter;
   private final RateLimiter globalSoftLimiter;
 
@@ -50,7 +50,7 @@ class ServiceRateLimiter extends ChannelDuplexHandler {
         buildHasher(hardLimiterMap, config.getRateLimiterPoolSize(), config.hardReqPerSec());
   }
 
-  private RendezvousHash buildHasher(
+  private RendezvousHash<CharSequence> buildHasher(
       Map<String, RateLimiter> limiterMap, int poolSize, double rate) {
     List<String> _tempPool = new ArrayList<>();
 
@@ -60,7 +60,7 @@ class ServiceRateLimiter extends ChannelDuplexHandler {
       limiterMap.put(id, RateLimiter.create(rate));
     }
 
-    return new RendezvousHash(Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), _tempPool);
+    return new RendezvousHash<>(Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), _tempPool);
   }
 
   @Override

--- a/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
+++ b/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
@@ -22,12 +22,12 @@ class RendezvousHashTest {
       mm.put(("Host" + i), new ArrayList<>());
     }
 
-    RendezvousHash rendezvousHash =
-        new RendezvousHash(Funnels.stringFunnel(Charset.defaultCharset()), nodeList);
+    RendezvousHash<CharSequence> rendezvousHash =
+        new RendezvousHash<>(Funnels.stringFunnel(Charset.defaultCharset()), nodeList);
     Random r = new Random();
     for (int i = 0; i < 100000; i++) {
       String thing = (Integer.toString(r.nextInt(123456789)));
-      List<String> hosts = rendezvousHash.get(thing.getBytes(), 3);
+      List<CharSequence> hosts = rendezvousHash.get(thing.getBytes(), 3);
       hosts.forEach(
           xs -> {
             mm.get(xs).add(thing);
@@ -55,8 +55,8 @@ class RendezvousHashTest {
             .put("d", "4")
             .put("e", "5")
             .build();
-    RendezvousHash hasher =
-        new RendezvousHash(Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), map.keySet());
+    RendezvousHash<CharSequence> hasher =
+        new RendezvousHash<>(Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), map.keySet());
     String k1 = "foo";
     String k2 = "bar";
     String k3 = "baz";

--- a/src/test/java/com/nordstrom/xrpc/client/XrpcClientTest.java
+++ b/src/test/java/com/nordstrom/xrpc/client/XrpcClientTest.java
@@ -65,8 +65,7 @@ class XrpcClientTest {
             assertEquals(true, false);
           }
         },
-        MoreExecutors.directExecutor()
-        );
+        MoreExecutors.directExecutor());
 
     try {
       latch.await(500, TimeUnit.MILLISECONDS);

--- a/src/test/java/com/nordstrom/xrpc/client/XrpcClientTest.java
+++ b/src/test/java/com/nordstrom/xrpc/client/XrpcClientTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.handler.codec.http.*;
 import java.net.URISyntaxException;
 import java.util.concurrent.CountDownLatch;
@@ -63,7 +64,9 @@ class XrpcClientTest {
             latch.countDown();
             assertEquals(true, false);
           }
-        });
+        },
+        MoreExecutors.directExecutor()
+        );
 
     try {
       latch.await(500, TimeUnit.MILLISECONDS);

--- a/src/test/java/com/nordstrom/xrpc/server/RouterTest.java
+++ b/src/test/java/com/nordstrom/xrpc/server/RouterTest.java
@@ -27,9 +27,9 @@ class RouterTest {
     Handler h6 = xrpcRequest -> null;
 
     // Test Basic operation
-    r.addRoute("/foo", h1);
-    r.addRoute("/foo/bar", h2);
-    r.addRoute("/baz", h3);
+    r.any("/foo", h1);
+    r.any("/foo/bar", h2);
+    r.any("/baz", h3);
     r.any("/baz/.*", h4);
     r.get("/people/{person}", h5);
     r.post("/people/{person}", h6);


### PR DESCRIPTION
There were a number of unchecked operations (especially on `RendezvousHash` usage), and a few calls to deprecated methods.

`addCallback` in particular is slated to be removed in April.