### PR TITLE
Multi-argument log with format string instead of using concatenation.

### DIFF
--- a/src/main/java/com/nordstrom/xrpc/client/Call.java
+++ b/src/main/java/com/nordstrom/xrpc/client/Call.java
@@ -163,16 +163,15 @@ public class Call {
                 f.setException(e);
               }
             } else {
-              log.debug("Xrpc connected to: " + server);
+              log.debug("Xrpc connected to: {}", server);
               String hostname = server.getAddress().getHostAddress();
               if (hostname.equals("localhost")) {
                 hostname = "127.0.0.1";
               }
               log.debug(
-                  "Adding hostname: "
-                      + hostname
-                      + ":"
-                      + ((InetSocketAddress) future.channel().remoteAddress()).getPort());
+                  "Adding hostname: {}:{}",
+                  hostname,
+                  ((InetSocketAddress) future.channel().remoteAddress()).getPort());
               f.set(future);
             }
           }

--- a/src/main/java/com/nordstrom/xrpc/client/XUrl.java
+++ b/src/main/java/com/nordstrom/xrpc/client/XUrl.java
@@ -51,7 +51,7 @@ public class XUrl {
     try {
       return getDomainChecked(url);
     } catch (URISyntaxException e) {
-      log.info("Malformed url: " + url);
+      log.info("Malformed url: {}", url);
       return null;
     }
   }
@@ -72,7 +72,7 @@ public class XUrl {
         return uri.getPort();
       }
     } catch (URISyntaxException e) {
-      log.info("Malformed url: " + url);
+      log.info("Malformed url: {}", url);
       return -1;
     }
   }
@@ -89,7 +89,7 @@ public class XUrl {
     try {
       return new URI(url).getPath();
     } catch (URISyntaxException e) {
-      log.info("Malformed url: " + url);
+      log.info("Malformed url: {}", url);
       return null;
     }
   }

--- a/src/main/java/com/nordstrom/xrpc/client/retry/ExponentialBackoffRetry.java
+++ b/src/main/java/com/nordstrom/xrpc/client/retry/ExponentialBackoffRetry.java
@@ -65,8 +65,7 @@ public class ExponentialBackoffRetry extends SleepingRetry {
 
   private static int validateMaxRetries(int maxRetries) {
     if (maxRetries > MAX_RETRIES_LIMIT) {
-      log.warn(
-          String.format("maxRetries too large (%d). Pinning to %d", maxRetries, MAX_RETRIES_LIMIT));
+      log.warn("maxRetries too large ({}). Pinning to {}", maxRetries, MAX_RETRIES_LIMIT);
       maxRetries = MAX_RETRIES_LIMIT;
     }
     return maxRetries;
@@ -81,7 +80,7 @@ public class ExponentialBackoffRetry extends SleepingRetry {
     // copied from Hadoop's RetryPolicies.java
     int sleepMs = baseSleepTimeMs * Math.max(1, random.nextInt(1 << (retryCount + 1)));
     if (sleepMs > maxSleepMs) {
-      log.warn(String.format("Sleep extension too large (%d). Pinning to %d", sleepMs, maxSleepMs));
+      log.warn("Sleep extension too large ({}). Pinning to {}", sleepMs, maxSleepMs);
       sleepMs = maxSleepMs;
     }
     return sleepMs;

--- a/src/main/java/com/nordstrom/xrpc/logging/ExceptionLogger.java
+++ b/src/main/java/com/nordstrom/xrpc/logging/ExceptionLogger.java
@@ -36,6 +36,6 @@ public class ExceptionLogger extends LoggingHandler {
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-    log.error("Exception caught: " + ctx + cause.getMessage(), cause);
+    log.error("Exception caught, context={}:", ctx, cause);
   }
 }

--- a/src/main/java/com/nordstrom/xrpc/server/Firewall.java
+++ b/src/main/java/com/nordstrom/xrpc/server/Firewall.java
@@ -40,7 +40,7 @@ class Firewall extends ChannelDuplexHandler {
   public void channelActive(ChannelHandlerContext ctx) throws Exception {
     if (ctx.channel().hasAttr(XrpcConstants.XRPC_HARD_RATE_LIMITED)) {
       if (log.isErrorEnabled()) {
-        log.error("Channel " + ctx.channel() + " Closed due to Xrpc Hard Rate Limit being reached");
+        log.error("Channel {} Closed due to Xrpc Hard Rate Limit being reached", ctx.channel());
       }
 
       rateLimits.mark();
@@ -49,7 +49,7 @@ class Firewall extends ChannelDuplexHandler {
 
     if ((ctx.channel().hasAttr(XrpcConstants.IP_BLACK_LIST))) {
       if (log.isErrorEnabled()) {
-        log.error("Channel " + ctx.channel() + " Closed due to Xrpc IP Black List Configuration");
+        log.error("Channel {} Closed due to Xrpc IP Black List Configuration", ctx.channel());
       }
       ctx.channel().closeFuture();
     }
@@ -57,7 +57,7 @@ class Firewall extends ChannelDuplexHandler {
     // This will always be set to False
     if ((ctx.channel().hasAttr(XrpcConstants.IP_WHITE_LIST))) {
       if (log.isErrorEnabled()) {
-        log.error(ctx.channel() + " is not a white listed client. Dropping Connection");
+        log.error("{} is not a white listed client. Dropping Connection", ctx.channel());
       }
       ctx.channel().closeFuture();
     }

--- a/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
+++ b/src/main/java/com/nordstrom/xrpc/server/ServiceRateLimiter.java
@@ -89,7 +89,7 @@ class ServiceRateLimiter extends ChannelDuplexHandler {
     if (config.getClientRateLimitOverride().containsKey(remoteAddress)) {
       if (hardLimiterMap.containsKey(remoteAddress)) {
         if (!hardLimiterMap.get(remoteAddress).tryAcquire()) {
-          log.debug("Hard Rate limit fired for " + remoteAddress);
+          log.debug("Hard Rate limit fired for {}", remoteAddress);
           ctx.channel().attr(XrpcConstants.XRPC_HARD_RATE_LIMITED).set(Boolean.TRUE);
         } else if (!softLimiterMap.get(remoteAddress).tryAcquire()) {
           ctx.channel().attr(XrpcConstants.XRPC_SOFT_RATE_LIMITED).set(Boolean.TRUE);


### PR DESCRIPTION
More correct; nominally faster for `debug`-level logs. Probably nominally slower for non-`debug` logs. Perf testing was a wash (which triggers lots of error strings, but is at INFO level).