### PR TITLE
Fix some cache issues with metrics names

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/MetricsUtil.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/MetricsUtil.java
@@ -2,13 +2,13 @@ package com.nordstrom.xrpc.server;
 
 import com.nordstrom.xrpc.server.http.Route;
 import com.nordstrom.xrpc.server.http.XHttpMethod;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MetricsUtil {
 
-  private static Map<Route, String> routeIdentifierMap = new HashMap<>();
+  private static Map<Route, String> routeIdentifierMap = new ConcurrentHashMap<>();
 
   protected static String getMeterNameForRoute(Route route, XHttpMethod httpMethod) {
     return getMeterNameForRoute(route, httpMethod.name());

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/http/Route.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/http/Route.java
@@ -127,4 +127,18 @@ public class Route {
   public String toString() {
     return originalPath;
   }
+
+  /** Two routes are considered equal if their original path specification was identical. */
+  @Override
+  public boolean equals(Object that) {
+    if (!(that instanceof Route)) {
+      return false;
+    }
+    return ((Route) that).originalPath.equals(this.originalPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.originalPath.hashCode();
+  }
 }


### PR DESCRIPTION
Name cache needs to be thread-safe.

Also, `Route` wasn't overriding `equals` or `hashCode`, so it's not going to work very well as a hash key.