### PR TITLE
Health & metrics cleanup

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -52,6 +52,7 @@ public class XConfig {
   private final String workerNameFormat;
   private final int bossThreadCount;
   private final int workerThreadCount;
+  private final int asyncHealthCheckThreadCount;
   private final int maxConnections;
   private final double softReqPerSec;
   private final double hardReqPerSec;
@@ -103,6 +104,7 @@ public class XConfig {
     workerNameFormat = config.getString("worker_name_format");
     bossThreadCount = config.getInt("boss_thread_count");
     workerThreadCount = config.getInt("worker_thread_count");
+    asyncHealthCheckThreadCount = config.getInt("async_health_check_thread_count");
     maxConnections = config.getInt("max_connections");
     rateLimiterPoolSize = config.getInt("rate_limiter_pool_size");
     softReqPerSec = config.getDouble("soft_req_per_sec");

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
@@ -181,8 +181,8 @@ public class AdminHandlers {
    */
   // CHECKSTYLE:ON
   public static Handler metricsHandler(MetricRegistry metrics, ObjectMapper mapper) {
-    Preconditions.checkState(metrics != null);
-    Preconditions.checkState(mapper != null);
+    Preconditions.checkArgument(metrics != null, "metrics may not be null");
+    Preconditions.checkArgument(mapper != null, "mapper may not be null");
     return xrpcRequest ->
         Recipes.newResponseOk(
             xrpcRequest
@@ -238,19 +238,18 @@ public class AdminHandlers {
    */
   public static Handler healthCheckHandler(
       HealthCheckRegistry healthCheckRegistry, ObjectMapper mapper) {
-    Preconditions.checkState(healthCheckRegistry != null);
-    Preconditions.checkState(mapper != null);
+    Preconditions.checkArgument(healthCheckRegistry != null, "healthCheckRegistry may not be null");
+    Preconditions.checkArgument(mapper != null, "mapper may not be null");
 
-    SortedMap<String, HealthCheck.Result> healthChecks = healthCheckRegistry.runHealthChecks();
-
-    return xrpcRequest ->
-        Recipes.newResponseOk(
-            xrpcRequest
-                .getAlloc()
-                .directBuffer()
-                .writeBytes(
-                    mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(healthChecks)),
-            Recipes.ContentType.Application_Json);
+    return xrpcRequest -> {
+      SortedMap<String, HealthCheck.Result> healthChecks = healthCheckRegistry.runHealthChecks();
+      return Recipes.newResponseOk(
+          xrpcRequest
+              .getAlloc()
+              .directBuffer()
+              .writeBytes(mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(healthChecks)),
+          Recipes.ContentType.Application_Json);
+    };
   }
 
   /**

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Router.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Router.java
@@ -49,7 +49,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Getter;
@@ -65,8 +64,7 @@ public class Router {
   private final MetricRegistry metricRegistry = new MetricRegistry();
 
   @Getter private Channel channel;
-  @Getter private HealthCheckRegistry healthCheckRegistry;
-  private final Map<String, HealthCheck> healthCheckMap = new ConcurrentHashMap<>();
+  @Getter private final HealthCheckRegistry healthCheckRegistry;
 
   public Router(Config config) {
     this(new XConfig(config));
@@ -75,6 +73,7 @@ public class Router {
   public Router(XConfig config) {
     this.config = config;
     this.tls = new Tls(config.cert(), config.key());
+    this.healthCheckRegistry = new HealthCheckRegistry(config.asyncHealthCheckThreadCount());
 
     XrpcConnectionContext.Builder contextBuilder =
         XrpcConnectionContext.builder()
@@ -101,15 +100,13 @@ public class Router {
 
     // Create the proper metrics containers.
     for (Map.Entry<HttpResponseStatus, String> entry : namesByCode.entrySet()) {
-      String meterName = "responseCodes." + entry.getValue();
+      String meterName = name("responseCodes", entry.getValue());
       contextBuilder.meterByStatusCode(entry.getKey(), metricRegistry.meter(meterName));
     }
   }
 
-  public void addHealthCheck(String s, HealthCheck check) {
-    Preconditions.checkState(
-        !healthCheckMap.containsKey(s), "A Health Check by that name has already been registered");
-    healthCheckMap.put(s, check);
+  public void addHealthCheck(String name, HealthCheck check) {
+    healthCheckRegistry.register(name, check);
   }
 
   public void scheduleHealthChecks(EventLoopGroup workerGroup) {
@@ -118,10 +115,6 @@ public class Router {
 
   public void scheduleHealthChecks(
       EventLoopGroup workerGroup, int initialDelay, int delay, TimeUnit timeUnit) {
-
-    for (Map.Entry<String, HealthCheck> entry : healthCheckMap.entrySet()) {
-      healthCheckRegistry.register(entry.getKey(), entry.getValue());
-    }
 
     workerGroup.scheduleWithFixedDelay(
         () -> healthCheckRegistry.runHealthChecks(workerGroup), initialDelay, delay, timeUnit);
@@ -301,9 +294,7 @@ public class Router {
     b.childHandler(initializer(state));
 
     if (config.runBackgroundHealthChecks()) {
-      final EventLoopGroup _workerGroup = b.config().childGroup();
-      healthCheckRegistry = new HealthCheckRegistry(_workerGroup);
-      scheduleHealthChecks(_workerGroup);
+      scheduleHealthChecks(b.config().childGroup());
     }
 
     if (config.serveAdminRoutes()) {
@@ -358,8 +349,6 @@ public class Router {
     ImmutableSortedMap<Route, List<ImmutableMap<XHttpMethod, Handler>>> routes =
         ctx.getRoutes().get();
 
-    final String namePrefix = "routes.";
-
     if (routes != null) {
       for (Map.Entry<Route, List<ImmutableMap<XHttpMethod, Handler>>> entry : routes.entrySet()) {
         Route route = entry.getKey();
@@ -367,8 +356,7 @@ public class Router {
         for (ImmutableMap<XHttpMethod, Handler> map : entry.getValue()) {
           for (XHttpMethod httpMethod : map.keySet()) {
             String routeName = MetricsUtil.getMeterNameForRoute(route, httpMethod);
-            ctx.getMetersByRoute()
-                .put(routeName, metricRegistry.meter(name(namePrefix + routeName)));
+            ctx.getMetersByRoute().put(routeName, metricRegistry.meter(name("routes", routeName)));
           }
         }
       }

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -25,6 +25,12 @@ worker_name_format = "xrpc-worker-%d"
 boss_thread_count = 4
 # The size of the worker thread group which processes requests and sends the results to clients.
 worker_thread_count = 40
+# The core size of the thread pool used for async health checks (how many threads to keep running
+# even when idle). This should be zero unless you explicitly add asynchronous checks, and should
+# usually be 1 or 2 at most.
+# See http://metrics.dropwizard.io/4.0.0/apidocs/com/codahale/metrics/health/annotation/Async.html
+# for documentaton on making checks asynchronous.
+async_health_check_thread_count = 0
 
 # The maximum number of concurrent connections to accept at once before dropping new connections.
 # Set to zero to disable connection limiting.


### PR DESCRIPTION
Fixes #115 . It also fixes an unfiled bug where health checks are ran once before the handler lambda is created instead of once per invocation of `/health`.

This also uses a nonworker pool for health checks to avoid thread starvation. Pool size is resting-state zero by default.