### PR TITLE
Add a RouteBuilder mixin-style interface for things that build routes.

### DIFF
--- a/demos/dino/src/main/java/com/nordstrom/xrpc/demos/dino/Application.java
+++ b/demos/dino/src/main/java/com/nordstrom/xrpc/demos/dino/Application.java
@@ -25,7 +25,6 @@ import com.nordstrom.xrpc.demos.dino.proto.DinoGetRequest;
 import com.nordstrom.xrpc.demos.dino.proto.DinoSetReply;
 import com.nordstrom.xrpc.demos.dino.proto.DinoSetRequest;
 import com.nordstrom.xrpc.server.Handler;
-import com.nordstrom.xrpc.server.Routes;
 import com.nordstrom.xrpc.server.Server;
 import com.nordstrom.xrpc.server.XrpcRequest;
 import com.nordstrom.xrpc.server.http.Recipes;
@@ -51,12 +50,9 @@ public class Application {
     // overrides from environment variables.
     Config config = ConfigFactory.load("demo.conf");
 
-    // Create your route builder. You use this to register request handlers.
-    Routes routes = new Routes();
-
     // Build your server. This overrides the default configuration with values from
     // src/main/resources/demo.conf.
-    Server server = new Server(config, routes);
+    Server server = new Server(config);
 
     // RPC style endpoint.
     Handler dinoHandler =
@@ -73,7 +69,7 @@ public class Application {
         };
 
     // Add predefined handler for HTTP GET:/DinoService/{method}
-    routes.get("/DinoService/{method}", dinoHandler);
+    server.get("/DinoService/{method}", dinoHandler);
 
     // Add a service specific health check.
     server.addHealthCheck("simple", new SimpleHealthCheck());

--- a/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/Application.java
+++ b/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/Application.java
@@ -17,7 +17,6 @@
 package com.nordstrom.xrpc.demos.people;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.nordstrom.xrpc.server.Routes;
 import com.nordstrom.xrpc.server.Server;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -31,14 +30,12 @@ public class Application {
     // overrides from environment variables.
     Config config = ConfigFactory.load("demo.conf");
 
-    Routes routes = new Routes();
-
     // Build your server. This overrides the default configuration with values from
     // src/main/resources/demo.conf.
-    Server server = new Server(config, routes);
+    Server server = new Server(config);
 
     // Add handlers for /people routes
-    new PeopleRoutes(routes);
+    new PeopleRoutes(server);
 
     // Add a service specific health check
     server.addHealthCheck("simple", new SimpleHealthCheck());

--- a/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/PeopleRoutes.java
+++ b/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/PeopleRoutes.java
@@ -1,7 +1,7 @@
 package com.nordstrom.xrpc.demos.people;
 
 import com.nordstrom.xrpc.server.Handler;
-import com.nordstrom.xrpc.server.RouteBuilder;
+import com.nordstrom.xrpc.server.Routes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -10,7 +10,7 @@ import lombok.Value;
 public class PeopleRoutes {
   private final List<Person> people = new ArrayList<>();
 
-  public PeopleRoutes(RouteBuilder routes) {
+  public PeopleRoutes(Routes routes) {
     Handler getPeople = request -> request.okJsonResponse(people);
 
     Handler postPerson =

--- a/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/PeopleRoutes.java
+++ b/demos/people/src/main/java/com/nordstrom/xrpc/demos/people/PeopleRoutes.java
@@ -1,7 +1,7 @@
 package com.nordstrom.xrpc.demos.people;
 
 import com.nordstrom.xrpc.server.Handler;
-import com.nordstrom.xrpc.server.Routes;
+import com.nordstrom.xrpc.server.RouteBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -10,7 +10,7 @@ import lombok.Value;
 public class PeopleRoutes {
   private final List<Person> people = new ArrayList<>();
 
-  public PeopleRoutes(Routes routes) {
+  public PeopleRoutes(RouteBuilder routes) {
     Handler getPeople = request -> request.okJsonResponse(people);
 
     Handler postPerson =

--- a/demos/request-response-pipeline/src/main/java/com/nordstrom/xrpc/pipelinedemo/Example.java
+++ b/demos/request-response-pipeline/src/main/java/com/nordstrom/xrpc/pipelinedemo/Example.java
@@ -21,7 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.collect.ImmutableMap;
 import com.nordstrom.xrpc.logging.ExceptionLogger;
 import com.nordstrom.xrpc.server.IdleDisconnectHandler;
-import com.nordstrom.xrpc.server.Routes;
 import com.nordstrom.xrpc.server.Server;
 import com.nordstrom.xrpc.server.State;
 import com.typesafe.config.Config;
@@ -121,7 +120,7 @@ public class Example {
     // Build your server. This overrides the default configuration with values from
     // src/main/resources/demo.conf.
     Server server =
-        new Server(config, new Routes()) {
+        new Server(config) {
           @Override
           public ChannelInitializer<Channel> initializer(State state) {
             return new MyChannelInitializer(state, routes);

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/RouteBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/RouteBuilder.java
@@ -16,115 +16,50 @@
 
 package com.nordstrom.xrpc.server;
 
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Preconditions;
+import com.nordstrom.xrpc.server.http.Route;
 import io.netty.handler.codec.http.HttpMethod;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
-/** Interface for constructing routes. */
-public interface RouteBuilder {
-  /**
-   * Binds a handler for GET requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a GET handler for the route.
-   */
-  default RouteBuilder get(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.GET);
+/** Class to build routes for a server to handle. */
+@Slf4j
+public class RouteBuilder implements Routes {
+  private final Map<Route, Map<HttpMethod, Handler>> routes = new HashMap<>();
+
+  @Override
+  public Routes addRoute(String routePattern, Handler handler, HttpMethod method) {
+    Preconditions.checkArgument(routePattern != null, "routePattern must not be null");
+    Preconditions.checkArgument(!routePattern.isEmpty(), "routePattern must not be empty");
+    Preconditions.checkArgument(handler != null, "handler must not be null");
+    Preconditions.checkArgument(method != null, "method must not be null");
+
+    Route route = Route.build(routePattern);
+
+    Map<HttpMethod, Handler> methods = routes.get(route);
+    if (methods == null) {
+      methods = new HashMap<>();
+      routes.put(route, methods);
+    }
+
+    // Verify that this method doesn't already exist.
+    Preconditions.checkArgument(
+        !methods.containsKey(method),
+        String.format(
+            "route %s already has a handler defined for method %s", route, method.toString()));
+
+    methods.put(method, handler);
+
+    return this;
   }
 
   /**
-   * Binds a handler for POST requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a POST handler for the route.
+   * Returns the routes compiled from this builder, using the given MetricRegistry to track access
+   * statistics.
    */
-  default RouteBuilder post(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.POST);
+  public CompiledRoutes compile(MetricRegistry metricRegistry) {
+    return new CompiledRoutes(this.routes, metricRegistry);
   }
-
-  /**
-   * Binds a handler for PUT requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a PUT handler for the route.
-   */
-  default RouteBuilder put(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.PUT);
-  }
-
-  /**
-   * Binds a handler for DELETE requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a DELETE handler for the route.
-   */
-  default RouteBuilder delete(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.DELETE);
-  }
-
-  /**
-   * Binds a handler for HEAD requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a HEAD handler for the route.
-   */
-  default RouteBuilder head(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.HEAD);
-  }
-
-  /**
-   * Binds a handler for OPTIONS requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a OPTIONS handler for the route.
-   */
-  default RouteBuilder options(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.OPTIONS);
-  }
-
-  /**
-   * Binds a handler for PATCH requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a PATCH handler for the route.
-   */
-  default RouteBuilder patch(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.PATCH);
-  }
-
-  /**
-   * Binds a handler for TRACE requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a TRACE handler for the route.
-   */
-  default RouteBuilder trace(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.TRACE);
-  }
-
-  /**
-   * Binds a handler for CONNECT requests to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a CONNECT handler for the route.
-   */
-  default RouteBuilder connect(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.CONNECT);
-  }
-
-  /**
-   * Binds a handler for the given method to the given route.
-   *
-   * @return this builder
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a handler for the given method + route pair.
-   */
-  RouteBuilder addRoute(String routePattern, Handler handler, HttpMethod method);
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/RouteBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/RouteBuilder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.server;
+
+import io.netty.handler.codec.http.HttpMethod;
+
+/** Interface for constructing routes. */
+public interface RouteBuilder {
+  /**
+   * Binds a handler for GET requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a GET handler for the route.
+   */
+  default RouteBuilder get(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.GET);
+  }
+
+  /**
+   * Binds a handler for POST requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a POST handler for the route.
+   */
+  default RouteBuilder post(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.POST);
+  }
+
+  /**
+   * Binds a handler for PUT requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a PUT handler for the route.
+   */
+  default RouteBuilder put(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.PUT);
+  }
+
+  /**
+   * Binds a handler for DELETE requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a DELETE handler for the route.
+   */
+  default RouteBuilder delete(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.DELETE);
+  }
+
+  /**
+   * Binds a handler for HEAD requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a HEAD handler for the route.
+   */
+  default RouteBuilder head(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.HEAD);
+  }
+
+  /**
+   * Binds a handler for OPTIONS requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a OPTIONS handler for the route.
+   */
+  default RouteBuilder options(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.OPTIONS);
+  }
+
+  /**
+   * Binds a handler for PATCH requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a PATCH handler for the route.
+   */
+  default RouteBuilder patch(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.PATCH);
+  }
+
+  /**
+   * Binds a handler for TRACE requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a TRACE handler for the route.
+   */
+  default RouteBuilder trace(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.TRACE);
+  }
+
+  /**
+   * Binds a handler for CONNECT requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a CONNECT handler for the route.
+   */
+  default RouteBuilder connect(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.CONNECT);
+  }
+
+  /**
+   * Binds a handler for the given method to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a handler for the given method + route pair.
+   */
+  RouteBuilder addRoute(String routePattern, Handler handler, HttpMethod method);
+}

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
@@ -26,100 +26,11 @@ import lombok.extern.slf4j.Slf4j;
 
 /** Class to build routes for a server to handle. */
 @Slf4j
-public class Routes {
+public class Routes implements RouteBuilder {
   private final Map<Route, Map<HttpMethod, Handler>> routes = new HashMap<>();
 
-  /**
-   * Binds a handler for GET requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a GET handler for the route.
-   */
-  public Routes get(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.GET);
-  }
-
-  /**
-   * Binds a handler for POST requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a POST handler for the route.
-   */
-  public Routes post(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.POST);
-  }
-
-  /**
-   * Binds a handler for PUT requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a PUT handler for the route.
-   */
-  public Routes put(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.PUT);
-  }
-
-  /**
-   * Binds a handler for DELETE requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a DELETE handler for the route.
-   */
-  public Routes delete(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.DELETE);
-  }
-
-  /**
-   * Binds a handler for HEAD requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a HEAD handler for the route.
-   */
-  public Routes head(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.HEAD);
-  }
-
-  /**
-   * Binds a handler for OPTIONS requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a OPTIONS handler for the route.
-   */
-  public Routes options(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.OPTIONS);
-  }
-
-  /**
-   * Binds a handler for PATCH requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a PATCH handler for the route.
-   */
-  public Routes patch(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.PATCH);
-  }
-
-  /**
-   * Binds a handler for TRACE requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a TRACE handler for the route.
-   */
-  public Routes trace(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.TRACE);
-  }
-
-  /**
-   * Binds a handler for CONNECT requests to the given route.
-   *
-   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
-   *     or if there is already a CONNECT handler for the route.
-   */
-  public Routes connect(String route, Handler handler) {
-    return addRoute(route, handler, HttpMethod.CONNECT);
-  }
-
-  private Routes addRoute(String routePattern, Handler handler, HttpMethod method) {
+  @Override
+  public RouteBuilder addRoute(String routePattern, Handler handler, HttpMethod method) {
     Preconditions.checkArgument(routePattern != null, "routePattern must not be null");
     Preconditions.checkArgument(!routePattern.isEmpty(), "routePattern must not be empty");
     Preconditions.checkArgument(handler != null, "handler must not be null");

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
@@ -16,50 +16,115 @@
 
 package com.nordstrom.xrpc.server;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Preconditions;
-import com.nordstrom.xrpc.server.http.Route;
 import io.netty.handler.codec.http.HttpMethod;
-import java.util.HashMap;
-import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 
-/** Class to build routes for a server to handle. */
-@Slf4j
-public class Routes implements RouteBuilder {
-  private final Map<Route, Map<HttpMethod, Handler>> routes = new HashMap<>();
-
-  @Override
-  public RouteBuilder addRoute(String routePattern, Handler handler, HttpMethod method) {
-    Preconditions.checkArgument(routePattern != null, "routePattern must not be null");
-    Preconditions.checkArgument(!routePattern.isEmpty(), "routePattern must not be empty");
-    Preconditions.checkArgument(handler != null, "handler must not be null");
-    Preconditions.checkArgument(method != null, "method must not be null");
-
-    Route route = Route.build(routePattern);
-
-    Map<HttpMethod, Handler> methods = routes.get(route);
-    if (methods == null) {
-      methods = new HashMap<>();
-      routes.put(route, methods);
-    }
-
-    // Verify that this method doesn't already exist.
-    Preconditions.checkArgument(
-        !methods.containsKey(method),
-        String.format(
-            "route %s already has a handler defined for method %s", route, method.toString()));
-
-    methods.put(method, handler);
-
-    return this;
+/** Interface for constructing routes. */
+public interface Routes {
+  /**
+   * Binds a handler for GET requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a GET handler for the route.
+   */
+  default Routes get(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.GET);
   }
 
   /**
-   * Returns the routes compiled from this builder, using the given MetricRegistry to track access
-   * statistics.
+   * Binds a handler for POST requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a POST handler for the route.
    */
-  public CompiledRoutes compile(MetricRegistry metricRegistry) {
-    return new CompiledRoutes(this.routes, metricRegistry);
+  default Routes post(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.POST);
   }
+
+  /**
+   * Binds a handler for PUT requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a PUT handler for the route.
+   */
+  default Routes put(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.PUT);
+  }
+
+  /**
+   * Binds a handler for DELETE requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a DELETE handler for the route.
+   */
+  default Routes delete(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.DELETE);
+  }
+
+  /**
+   * Binds a handler for HEAD requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a HEAD handler for the route.
+   */
+  default Routes head(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.HEAD);
+  }
+
+  /**
+   * Binds a handler for OPTIONS requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a OPTIONS handler for the route.
+   */
+  default Routes options(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.OPTIONS);
+  }
+
+  /**
+   * Binds a handler for PATCH requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a PATCH handler for the route.
+   */
+  default Routes patch(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.PATCH);
+  }
+
+  /**
+   * Binds a handler for TRACE requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a TRACE handler for the route.
+   */
+  default Routes trace(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.TRACE);
+  }
+
+  /**
+   * Binds a handler for CONNECT requests to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a CONNECT handler for the route.
+   */
+  default Routes connect(String route, Handler handler) {
+    return addRoute(route, handler, HttpMethod.CONNECT);
+  }
+
+  /**
+   * Binds a handler for the given method to the given route.
+   *
+   * @return this builder
+   * @throws IllegalArgumentException if either the route or handler is null; if the route is empty;
+   *     or if there is already a handler for the given method + route pair.
+   */
+  Routes addRoute(String routePattern, Handler handler, HttpMethod method);
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/CorsTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/CorsTest.java
@@ -29,7 +29,6 @@ class CorsTest {
   private OkHttpClient client;
   private Config config;
   private Server server;
-  private Routes routes;
 
   @BeforeEach
   void beforeEach() {
@@ -39,7 +38,6 @@ class CorsTest {
             .withValue("serve_admin_routes", fromAnyRef(false))
             .withValue("run_background_health_checks", fromAnyRef(false));
     client = UnsafeHttp.unsafeClient();
-    routes = new Routes();
   }
 
   @AfterEach
@@ -87,8 +85,8 @@ class CorsTest {
   void testCorsEnabledInFlight() throws IOException {
     addConfigValue("cors.enable", fromAnyRef(true));
     addConfigValue("cors.allowed_origins", fromIterable(ImmutableList.of("foo.bar")));
-    routes.get("/people", req -> Recipes.newResponseOk("hello foo.bar"));
     init();
+    server.get("/people", req -> Recipes.newResponseOk("hello foo.bar"));
     start();
 
     Request request =
@@ -147,7 +145,7 @@ class CorsTest {
   }
 
   private void init() {
-    server = new Server(new XConfig(config), routes);
+    server = new Server(new XConfig(config));
   }
 
   private void start() throws IOException {

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/RoutesTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/RoutesTest.java
@@ -30,14 +30,14 @@ import io.netty.handler.codec.http.HttpMethod;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
-/** Tests for Routes and CompiledRoutes. */
+/** Tests for RouteBuilder and CompiledRoutes. */
 class RoutesTest {
   /** Tests basic routing features. */
   @Test
   public void trivialRouteMatch() throws Exception {
     Handler mockHandler = mock(Handler.class);
 
-    Routes routes = new Routes();
+    RouteBuilder routes = new RouteBuilder();
     routes.get("/get", mockHandler);
 
     MetricRegistry registry = new MetricRegistry();
@@ -64,7 +64,7 @@ class RoutesTest {
     Handler mockGetHandler = mock(Handler.class);
     Handler mockPostHandler = mock(Handler.class);
 
-    Routes routes = new Routes();
+    RouteBuilder routes = new RouteBuilder();
     routes.get("/path", mockGetHandler).post("/path", mockPostHandler);
 
     MetricRegistry registry = new MetricRegistry();
@@ -92,7 +92,7 @@ class RoutesTest {
     Handler mockGroupsHandler = mock(Handler.class);
     Handler mockGetHandler = mock(Handler.class);
 
-    Routes routes = new Routes();
+    RouteBuilder routes = new RouteBuilder();
     routes.get("/path/{grp}", mockGroupsHandler).get("/path", mockGetHandler);
 
     MetricRegistry registry = new MetricRegistry();
@@ -112,7 +112,7 @@ class RoutesTest {
   /** Adding the same path+method should throw an exception. */
   @Test
   public void duplicateHandlerThrows() {
-    RouteBuilder routes = new Routes().get("/twice", request -> null);
+    Routes routes = new RouteBuilder().get("/twice", request -> null);
     assertThrows(IllegalArgumentException.class, () -> routes.get("/twice", request -> null));
   }
 }


### PR DESCRIPTION
I'm not sure that `Routes` _needs_ to implement the new interface, but it gets some extra features for free that way, since it already needs to implement the one abstract method.