### PR TITLE
HTTP/2 and max payload fixes

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -16,6 +16,7 @@
 
 package com.nordstrom.xrpc;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -107,12 +108,11 @@ public class XConfig {
     workerThreadCount = config.getInt("worker_thread_count");
     asyncHealthCheckThreadCount = config.getInt("async_health_check_thread_count");
     long maxPayloadBytesLong = config.getBytes("max_payload_bytes");
-    if (maxPayloadBytesLong > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          String.format(
-              "value %d for max_payload_bytes must be less than or equal to %d",
-              maxPayloadBytesLong, Integer.MAX_VALUE));
-    }
+    Preconditions.checkArgument(
+        maxPayloadBytesLong <= Integer.MAX_VALUE,
+        String.format(
+            "value %d for max_payload_bytes must be less than or equal to %d",
+            maxPayloadBytesLong, Integer.MAX_VALUE));
     maxPayloadBytes = (int) maxPayloadBytesLong;
     maxConnections = config.getInt("max_connections");
     rateLimiterPoolSize = config.getInt("rate_limiter_pool_size");

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -53,6 +53,7 @@ public class XConfig {
   private final int bossThreadCount;
   private final int workerThreadCount;
   private final int asyncHealthCheckThreadCount;
+  private final int maxPayloadBytes;
   private final int maxConnections;
   private final double softReqPerSec;
   private final double hardReqPerSec;
@@ -105,6 +106,14 @@ public class XConfig {
     bossThreadCount = config.getInt("boss_thread_count");
     workerThreadCount = config.getInt("worker_thread_count");
     asyncHealthCheckThreadCount = config.getInt("async_health_check_thread_count");
+    long maxPayloadBytesLong = config.getBytes("max_payload_bytes");
+    if (maxPayloadBytesLong > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          String.format(
+              "value %d for max_payload_bytes must be less than or equal to %d",
+              maxPayloadBytesLong, Integer.MAX_VALUE));
+    }
+    maxPayloadBytes = (int) maxPayloadBytesLong;
     maxConnections = config.getInt("max_connections");
     rateLimiterPoolSize = config.getInt("rate_limiter_pool_size");
     softReqPerSec = config.getDouble("soft_req_per_sec");

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -42,6 +42,8 @@ public class XrpcConstants {
   public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
   public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+  public static final byte[] PAYLOAD_EXCEEDED_RESPONSE =
+      "Request payload too large".getBytes(DEFAULT_CHARSET);
   public static final byte[] RATE_LIMIT_RESPONSE =
       "This response is being send due to too many requests being sent to the server"
           .getBytes(DEFAULT_CHARSET);

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -19,8 +19,6 @@ package com.nordstrom.xrpc;
 import com.nordstrom.xrpc.server.Handler;
 import com.nordstrom.xrpc.server.XrpcConnectionContext;
 import com.nordstrom.xrpc.server.XrpcRequest;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.util.AttributeKey;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -44,11 +42,9 @@ public class XrpcConstants {
   public static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
   public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-  public static final ByteBuf RATE_LIMIT_RESPONSE =
-      Unpooled.directBuffer()
-          .writeBytes(
-              "This response is being send due to too many requests being sent to the server"
-                  .getBytes(DEFAULT_CHARSET));
+  public static final byte[] RATE_LIMIT_RESPONSE =
+      "This response is being send due to too many requests being sent to the server"
+          .getBytes(DEFAULT_CHARSET);
   public static final AttributeKey<Boolean> IP_WHITE_LIST = AttributeKey.valueOf("IpWhiteList");
   public static final AttributeKey<Boolean> IP_BLACK_LIST = AttributeKey.valueOf("IpBlackList");
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -16,25 +16,12 @@
 
 package com.nordstrom.xrpc;
 
-import com.nordstrom.xrpc.server.Handler;
 import com.nordstrom.xrpc.server.XrpcConnectionContext;
-import com.nordstrom.xrpc.server.XrpcRequest;
 import io.netty.util.AttributeKey;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class XrpcConstants {
-  /**
-   * Stores the request object for HTTP/2 requests. The request is created when headers are read,
-   * and will be stored in the context if there is a request body coming in a later data frame.
-   */
-  public static final AttributeKey<XrpcRequest> XRPC_REQUEST = AttributeKey.valueOf("XrpcRequest");
-  /**
-   * Stores the handler for HTTP/2 requests. The handler is matched when headers are read, and will
-   * be stored in the context if there is a request body coming in a later data frame.
-   */
-  public static final AttributeKey<Handler> XRPC_HANDLER = AttributeKey.valueOf("XrpcHandler");
-
   public static final AttributeKey<Boolean> XRPC_SOFT_RATE_LIMITED =
       AttributeKey.valueOf("XrpcSoftRateLimited");
   public static final AttributeKey<Boolean> XRPC_HARD_RATE_LIMITED =

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/CompiledRoutes.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/CompiledRoutes.java
@@ -94,6 +94,17 @@ public class CompiledRoutes {
    *     handler returning 405 (method not allowed) will be returned. If no path matched, a handler
    *     returning 404 (not found) will be returned.
    */
+  public Match match(String path, String methodName) {
+    return match(path, HttpMethod.valueOf(methodName));
+  }
+
+  /**
+   * Gets the handler and matched groups for the given path and method.
+   *
+   * @return the handler for the given path and method. If a path matched, but no method matched, a
+   *     handler returning 405 (method not allowed) will be returned. If no path matched, a handler
+   *     returning 404 (not found) will be returned.
+   */
   public Match match(String path, HttpMethod method) {
     boolean pathMatched = false;
     for (Map.Entry<Route, ImmutableMap<HttpMethod, Handler>> routeToHandlers : routes.entrySet()) {

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -152,8 +152,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
     String path = getPathFromHeaders(headers);
     HttpMethod method = HttpMethod.valueOf(headers.method().toString());
     CompiledRoutes.Match match = xctx.getRoutes().match(path, method);
-    XrpcRequest request =
-        new XrpcRequest(headers, xctx.getMapper(), match.getGroups(), channel, streamId);
+    XrpcRequest request = new XrpcRequest(headers, xctx.getMapper(), match.getGroups(), channel);
     Optional<CharSequence> contentLength = Optional.ofNullable(headers.get(CONTENT_LENGTH));
     if (!contentLength.isPresent()) {
       // No request body expected; execute handler now with empty body.

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2Handler.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Meter;
 import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.client.XUrl;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -140,8 +141,7 @@ public final class Http2Handler extends Http2ConnectionHandler implements Http2F
           ctx,
           streamId,
           HttpResponseStatus.TOO_MANY_REQUESTS,
-          XrpcConstants.RATE_LIMIT_RESPONSE.retain());
-
+          Unpooled.wrappedBuffer(XrpcConstants.RATE_LIMIT_RESPONSE));
       return;
     }
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
@@ -33,16 +33,20 @@ public final class Http2HandlerBuilder
   /** Logger to query for configuration for HTTP2 frame logging. */
   private static final Logger FRAME_LOGGER = LoggerFactory.getLogger(FRAME_LOGGER_NAME);
 
-  private final int maxPayloadBytes;
+  private int maxPayloadBytes;
 
-  public Http2HandlerBuilder(int maxPayloadBytes) {
-    this.maxPayloadBytes = maxPayloadBytes;
-
+  public Http2HandlerBuilder() {
     if (FRAME_LOGGER.isDebugEnabled()) {
       frameLogger(new Http2FrameLogger(LogLevel.DEBUG, FRAME_LOGGER_NAME));
     }
   }
 
+  public Http2HandlerBuilder maxPayloadBytes(int maxPayloadBytes) {
+    this.maxPayloadBytes = maxPayloadBytes;
+    return this;
+  }
+
+  // Override build() to make public.
   @Override
   public Http2ConnectionHandler build() {
     return super.build();
@@ -54,6 +58,7 @@ public final class Http2HandlerBuilder
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
 
+    // TODO(jkinkead): Set MAX_CONCURRENT_STREAMS value to something from config.
     decoder.frameListener(new Http2Handler(encoder, maxPayloadBytes));
 
     ConnectionHandler handler = new ConnectionHandler(decoder, encoder, initialSettings);

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
@@ -28,7 +28,11 @@ public final class Http2HandlerBuilder
 
   private final Http2FrameLogger logger = new Http2FrameLogger(LogLevel.INFO, Http2Handler.class);
 
-  public Http2HandlerBuilder(XrpcConnectionContext xctx) {
+  private final int maxPayloadBytes;
+
+  public Http2HandlerBuilder(int maxPayloadBytes) {
+    this.maxPayloadBytes = maxPayloadBytes;
+
     frameLogger(logger);
   }
 
@@ -42,7 +46,7 @@ public final class Http2HandlerBuilder
       Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
-    Http2Handler handler = new Http2Handler(decoder, encoder, initialSettings);
+    Http2Handler handler = new Http2Handler(decoder, encoder, initialSettings, maxPayloadBytes);
     frameListener(handler);
     return handler;
   }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2OrHttpHandler.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2OrHttpHandler.java
@@ -51,7 +51,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
 
     if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
       ChannelPipeline cp = ctx.pipeline();
-      cp.addLast("codec", new Http2HandlerBuilder(maxPayloadBytes).build());
+      cp.addLast("codec", new Http2HandlerBuilder().maxPayloadBytes(maxPayloadBytes).build());
       return;
     }
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2OrHttpHandler.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2OrHttpHandler.java
@@ -31,17 +31,18 @@ import io.netty.util.AttributeKey;
 public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
   private static final AttributeKey<XrpcConnectionContext> CONNECTION_CONTEXT =
       AttributeKey.valueOf("XrpcConnectionContext");
-  private static final int MAX_PAYLOAD_SIZE = 1024 * 1024; // TODO(JR): This should be configurable
   private final UrlRouter router;
   private final XrpcConnectionContext xctx;
   private final CorsConfig corsConfig;
+  private final int maxPayloadBytes;
 
   protected Http2OrHttpHandler(
-      UrlRouter router, XrpcConnectionContext xctx, CorsConfig corsConfig) {
+      UrlRouter router, XrpcConnectionContext xctx, CorsConfig corsConfig, int maxPayloadBytes) {
     super(ApplicationProtocolNames.HTTP_1_1);
     this.router = router;
     this.xctx = xctx;
     this.corsConfig = corsConfig;
+    this.maxPayloadBytes = maxPayloadBytes;
   }
 
   @Override
@@ -50,14 +51,14 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
 
     if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
       ChannelPipeline cp = ctx.pipeline();
-      cp.addLast("codec", new Http2HandlerBuilder(xctx).build());
+      cp.addLast("codec", new Http2HandlerBuilder(maxPayloadBytes).build());
       return;
     }
 
     if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
       ChannelPipeline cp = ctx.pipeline();
       cp.addLast("codec", new HttpServerCodec());
-      cp.addLast("aggregator", new HttpObjectAggregator(MAX_PAYLOAD_SIZE));
+      cp.addLast("aggregator", new HttpObjectAggregator(maxPayloadBytes));
 
       if (corsConfig.isCorsSupportEnabled()) {
         cp.addLast("cors", new CorsHandler(corsConfig));

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
@@ -188,7 +188,9 @@ public class Server {
             .blackListFilter(new BlackListFilter(metricRegistry, config.ipBlackList()))
             .firewall(new Firewall(metricRegistry))
             .tls(tls)
-            .h1h2(new Http2OrHttpHandler(new UrlRouter(), ctx, config.corsConfig()))
+            .h1h2(
+                new Http2OrHttpHandler(
+                    new UrlRouter(), ctx, config.corsConfig(), config.maxPayloadBytes()))
             .build();
 
     ServerBootstrap b =

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.nordstrom.xrpc.XConfig;
 import com.nordstrom.xrpc.server.tls.Tls;
 import com.typesafe.config.Config;
@@ -102,7 +103,7 @@ public class Server implements Routes {
             .requestMeter(metricRegistry.meter("requests"))
             .exceptionHandler(new DefaultExceptionHandler())
             .mapper(new ObjectMapper());
-    addResponseCodeMeters(contextBuilder);
+    addResponseCodeMeters(contextBuilder, metricRegistry);
   }
 
   @Override
@@ -113,7 +114,9 @@ public class Server implements Routes {
   }
 
   /** Adds a meter for all HTTP response codes to the given XrpcConnectionContext. */
-  private void addResponseCodeMeters(XrpcConnectionContext.Builder contextBuilder) {
+  @VisibleForTesting
+  static void addResponseCodeMeters(
+      XrpcConnectionContext.Builder contextBuilder, MetricRegistry metricRegistry) {
     Map<HttpResponseStatus, String> namesByCode = new HashMap<>();
     namesByCode.put(HttpResponseStatus.OK, "ok");
     namesByCode.put(HttpResponseStatus.CREATED, "created");
@@ -123,6 +126,8 @@ public class Server implements Routes {
     namesByCode.put(HttpResponseStatus.UNAUTHORIZED, "unauthorized");
     namesByCode.put(HttpResponseStatus.FORBIDDEN, "forbidden");
     namesByCode.put(HttpResponseStatus.NOT_FOUND, "notFound");
+    // Note that the HTTP RFC name is "Payload Too Large"; REQUEST_ENTITY_TOO_LARGE is an old name.
+    namesByCode.put(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, "payloadTooLarge");
     namesByCode.put(HttpResponseStatus.TOO_MANY_REQUESTS, "tooManyRequests");
     namesByCode.put(HttpResponseStatus.INTERNAL_SERVER_ERROR, "serverError");
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -58,7 +58,6 @@ public class UrlRouter extends ChannelDuplexHandler {
       ObjectMapper mapper = xctx.getMapper();
       XrpcRequest xrpcRequest =
           new XrpcRequest(request, xctx.getMapper(), match.getGroups(), ctx.channel());
-      xrpcRequest.setData(request.content());
 
       HttpResponse resp = match.getHandler().handle(xrpcRequest);
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.client.XUrl;
 import com.nordstrom.xrpc.server.http.Recipes;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -42,7 +43,7 @@ public class UrlRouter extends ChannelDuplexHandler {
       ctx.writeAndFlush(
               Recipes.newResponse(
                   HttpResponseStatus.TOO_MANY_REQUESTS,
-                  XrpcConstants.RATE_LIMIT_RESPONSE.retain(),
+                  Unpooled.wrappedBuffer(XrpcConstants.RATE_LIMIT_RESPONSE),
                   Recipes.ContentType.Text_Plain))
           .addListener(ChannelFutureListener.CLOSE);
       xctx.getMetersByStatusCode().get(HttpResponseStatus.TOO_MANY_REQUESTS).mark();

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/UrlRouter.java
@@ -16,6 +16,7 @@
 
 package com.nordstrom.xrpc.server;
 
+import com.codahale.metrics.Meter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.client.XUrl;
@@ -60,7 +61,11 @@ public class UrlRouter extends ChannelDuplexHandler {
 
       HttpResponse resp = match.getHandler().handle(xrpcRequest);
 
-      xctx.metersByStatusCode().get(resp.status()).mark();
+      // TODO(jkinkead): Per issue #152, this should track ALL response codes.
+      Meter meter = xctx.metersByStatusCode().get(resp.status());
+      if (meter != null) {
+        meter.mark();
+      }
 
       ctx.writeAndFlush(resp).addListener(ChannelFutureListener.CLOSE);
     }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
@@ -23,6 +23,7 @@ import com.nordstrom.xrpc.server.http.Recipes;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -46,20 +47,30 @@ import lombok.extern.slf4j.Slf4j;
 public class XrpcRequest {
   private final ObjectMapper mapper;
 
-  /** The request to handle. */
-  @Getter private final FullHttpRequest h1Request;
+  /** The HTTP/1.x request to handle. null if this is an HTTP/2 request. */
+  private final FullHttpRequest h1Request;
 
-  @Getter private final Http2Headers h2Headers;
+  /** The HTTP/2 request headers. null if this is an HTTP/1.x request. */
+  private final Http2Headers h2Headers;
+
   @Getter private final EventLoop eventLoop;
   @Getter private final Channel upstreamChannel;
   @Getter private final ByteBufAllocator alloc;
+
   /** The variables captured from the route path. */
   private final Map<String, String> groups;
 
-  /** The parsed query string. */
+  /** The parsed query string. Lazily initialized in query(). */
   private HttpQuery query;
 
-  private ByteBuf data;
+  /** HTTP/2 request data. Null for HTTP/1.x requests. */
+  private final CompositeByteBuf data;
+
+  /**
+   * The fake HTTP/1.x request generated from HTTP/2 data. Instantiated in the first call to
+   * getHttpRequest, if this is an HTTP/2 request.
+   */
+  private FullHttpRequest synthesizedRequest;
 
   public XrpcRequest(
       FullHttpRequest request, ObjectMapper mapper, Map<String, String> groups, Channel channel) {
@@ -70,6 +81,7 @@ public class XrpcRequest {
     this.upstreamChannel = channel;
     this.alloc = channel.alloc();
     this.eventLoop = channel.eventLoop();
+    this.data = null;
   }
 
   public XrpcRequest(
@@ -81,6 +93,7 @@ public class XrpcRequest {
     this.upstreamChannel = channel;
     this.alloc = channel.alloc();
     this.eventLoop = channel.eventLoop();
+    this.data = alloc.compositeBuffer();
   }
 
   public HttpQuery query() {
@@ -106,31 +119,36 @@ public class XrpcRequest {
     return alloc.compositeDirectBuffer();
   }
 
-  public void setData(byte[] bytes) {
-    if (data == null) {
-      data = getByteBuf();
-    }
-
-    data.writeBytes(bytes);
+  /**
+   * Adds data to an HTTP/2 request. Normally called with each data frame read by the HTTP/2 codec.
+   *
+   * @return the total data size available to read after adding the provided buffer. This is the
+   *     total size of the data buffer, assuming no reads have been performed.
+   */
+  int addData(ByteBuf dataFrame) {
+    // CompositeByteBuf will take ownership of releasing the byte buf, per docs.
+    data.addComponent(true, dataFrame.retain());
+    return data.readableBytes();
   }
 
-  public void setData(ByteBuf buff) {
-    if (data == null) {
-      data = getByteBuf();
-    }
-
-    data.writeBytes(buff);
-  }
-
+  /**
+   * Returns the raw request buffer. Note that any reads will consume the buffer, so the caller is
+   * responsible for copying or resetting the buffer as needed.
+   */
   public ByteBuf getData() {
-    if (data == null) {
-      return getByteBuf();
+    if (h1Request != null) {
+      // HTTP/1.x request; return content directly.
+      return h1Request.content();
     }
 
+    // HTTP/2 request; return composite of data frames.
     return data;
   }
 
-  /** Returns a new string representing the request data, decoded using the appropriate charset. */
+  /**
+   * Returns a new string representing the request data, decoded using the appropriate charset. This
+   * does NOT consume or mutate the underlying data buffer.
+   */
   public String getDataAsString() {
     // Note that this defaults to iso-8859-1 per
     // https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1.
@@ -163,11 +181,14 @@ public class XrpcRequest {
       return h1Request;
     }
 
+    if (synthesizedRequest != null) {
+      return synthesizedRequest;
+    }
+
     if (h2Headers != null) {
       try {
         // Fake out a full HTTP request.
-        FullHttpRequest synthesizedRequest =
-            HttpConversionUtil.toFullHttpRequest(0, h2Headers, alloc, true);
+        this.synthesizedRequest = HttpConversionUtil.toFullHttpRequest(0, h2Headers, alloc, true);
         if (data != null) {
           synthesizedRequest.replace(data);
         }
@@ -175,7 +196,7 @@ public class XrpcRequest {
         return synthesizedRequest;
       } catch (Http2Exception e) {
         // TODO(JR): Do something more meaningful with this exception
-        e.printStackTrace();
+        throw new RuntimeException("Http2Exception synthesizing request", e);
       }
     }
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
@@ -59,7 +59,6 @@ public class XrpcRequest {
   /** The parsed query string. */
   private HttpQuery query;
 
-  private final int streamId;
   private ByteBuf data;
 
   public XrpcRequest(
@@ -71,15 +70,10 @@ public class XrpcRequest {
     this.upstreamChannel = channel;
     this.alloc = channel.alloc();
     this.eventLoop = channel.eventLoop();
-    this.streamId = -1;
   }
 
   public XrpcRequest(
-      Http2Headers headers,
-      ObjectMapper mapper,
-      Map<String, String> groups,
-      Channel channel,
-      int streamId) {
+      Http2Headers headers, ObjectMapper mapper, Map<String, String> groups, Channel channel) {
     this.h1Request = null;
     this.h2Headers = headers;
     this.mapper = mapper;
@@ -87,7 +81,6 @@ public class XrpcRequest {
     this.upstreamChannel = channel;
     this.alloc = channel.alloc();
     this.eventLoop = channel.eventLoop();
-    this.streamId = streamId;
   }
 
   public HttpQuery query() {

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/XrpcRequest.java
@@ -51,6 +51,7 @@ public class XrpcRequest {
   private final FullHttpRequest h1Request;
 
   /** The HTTP/2 request headers. null if this is an HTTP/1.x request. */
+  @Getter(AccessLevel.PACKAGE)
   private final Http2Headers h2Headers;
 
   @Getter private final EventLoop eventLoop;

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -9,6 +9,11 @@ serve_admin_routes = true
 # If true, run regular health checks in a background thread. This is useful for logging.
 run_background_health_checks = true
 
+# The maximum HTTP payload allowed, for HTTP/2 and HTTP/1.x requests.
+# Netty HTTP/1.x support requires that this be an integer, so values greater than 2Gi are not
+# supported.
+max_payload_bytes = 10Mi
+
 # The maximum allowed time between reads before timing out. Set to zero to disable read timeouts.
 reader_idle_timeout_seconds = 200
 # The maximum allowed time between writes before timing out. Set to zero to disable write timeouts.

--- a/xrpc/src/test/java/com/nordstrom/xrpc/HttpQueryTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/HttpQueryTest.java
@@ -54,7 +54,7 @@ class HttpQueryTest {
   void testH2Query() {
     DefaultHttp2Headers headers = new DefaultHttp2Headers();
     headers.path("?p1=v1");
-    XrpcRequest r = new XrpcRequest(headers, null, null, new EmbeddedChannel(), 0);
+    XrpcRequest r = new XrpcRequest(headers, null, null, new EmbeddedChannel());
     assertNotNull(r);
     assertEquals("v1", r.query().parameter("p1").get());
   }
@@ -63,6 +63,6 @@ class HttpQueryTest {
   void testQueryWithIllegalState() {
     assertThrows(
         IllegalStateException.class,
-        () -> new XrpcRequest(null, null, null, new EmbeddedChannel()).query());
+        () -> new XrpcRequest((FullHttpRequest) null, null, null, new EmbeddedChannel()).query());
   }
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/Http2HandlerTest.java
@@ -17,30 +17,339 @@
 package com.nordstrom.xrpc.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.nordstrom.xrpc.XrpcConstants;
+import com.nordstrom.xrpc.server.http.Recipes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Headers;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class Http2HandlerTest {
+  private static final int MAX_PAYLOAD = 1024;
+  /** Path which has a handler registered. */
+  private static final String OK_PATH = "/foo";
+  /** Handler for OK_PATH and /bar/{param}. Echoes any request body back. */
+  private static final Handler OK_HANDLER =
+      request -> {
+        ByteBuf data = request.getData();
+        if (data.readableBytes() > 0) {
+          return Recipes.newResponse(
+              HttpResponseStatus.OK, data, Recipes.ContentType.Application_Octet_Stream);
+        } else {
+          return Recipes.newResponse(HttpResponseStatus.OK);
+        }
+      };
+  /** Path prefix which has a handler with paramter. */
+  private static final String PARAM_PATH_PREFIX = "/bar";
+  /** Group name for the path with a group. */
+  private static final String PARAM_NAME = "param";
+  /** Stream ID used in most tests. */
+  private static final int STREAM_ID = 33;
+
+  private MetricRegistry metricRegistry = new MetricRegistry();
+
+  private Meter requestMeter = metricRegistry.meter("requests");
+
+  private EmbeddedChannel channel = new EmbeddedChannel();
+
+  private Http2Headers headers = new DefaultHttp2Headers();
+
+  private XrpcConnectionContext xrpcContext;
+
+  private Http2Handler testHandler;
+
+  @Mock private ChannelHandlerContext mockContext;
+
+  @Mock private Http2Connection mockConnection;
+
+  @Mock private Http2ConnectionEncoder mockEncoder;
+
+  @BeforeEach
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+    when(mockEncoder.connection()).thenReturn(mockConnection);
+    when(mockContext.channel()).thenReturn(channel);
+  }
+
+  @BeforeEach
+  public void initContext() {
+    XrpcConnectionContext.Builder contextBuilder =
+        XrpcConnectionContext.builder().requestMeter(requestMeter);
+    Server.addResponseCodeMeters(contextBuilder, metricRegistry);
+    RouteBuilder routeBuilder = new RouteBuilder();
+    routeBuilder
+        .get(OK_PATH, OK_HANDLER)
+        .get(String.format("%s/{%s}", PARAM_PATH_PREFIX, PARAM_NAME), OK_HANDLER);
+    contextBuilder.routes(routeBuilder.compile(metricRegistry));
+    xrpcContext = contextBuilder.build();
+
+    channel.attr(XrpcConstants.CONNECTION_CONTEXT).set(xrpcContext);
+  }
+
+  /** Helper which verifies that no response was written to the mock encoder. */
+  void verifyNoResponse() {
+    verify(mockEncoder, never())
+        .writeHeaders(any(), anyInt(), any(), anyInt(), anyBoolean(), any());
+    verify(mockEncoder, never()).writeData(any(), anyInt(), any(), anyInt(), anyBoolean(), any());
+  }
+
+  /** Helper which verifies that the given response data was written to the mock encoder. */
+  void verifyResponse(HttpResponseStatus status, Optional<ByteBuf> responseBody, int streamId) {
+    ArgumentMatcher<Http2Headers> matchesStatus =
+        new ArgumentMatcher<Http2Headers>() {
+          @Override
+          public boolean matches(Http2Headers headers) {
+            return status.codeAsText().equals(headers.status());
+          }
+
+          @Override
+          public String toString() {
+            return String.format("Http2Headers[:status: %s]", status.codeAsText());
+          }
+        };
+    if (responseBody.isPresent()) {
+      // Both headers and data should've been sent.
+      verify(mockEncoder, times(1))
+          .writeHeaders(
+              eq(mockContext), eq(streamId), argThat(matchesStatus), anyInt(), eq(false), any());
+      verify(mockEncoder, times(1))
+          .writeData(
+              eq(mockContext), eq(streamId), eq(responseBody.get()), anyInt(), eq(true), any());
+    } else {
+      // Only headers should've been sent.
+      verify(mockEncoder, times(1))
+          .writeHeaders(
+              eq(mockContext), eq(streamId), argThat(matchesStatus), anyInt(), eq(true), any());
+      verify(mockEncoder, never()).writeData(any(), anyInt(), any(), anyInt(), anyBoolean(), any());
+    }
+
+    // Verify that the response meter was marked.
+    assertEquals(
+        1L,
+        xrpcContext.metersByStatusCode().get(status).getCount(),
+        "meter " + status.codeAsText() + " should have been marked");
+  }
+
   @Test
   public void getPathFromHeaders_withQueryString() {
-    Http2Headers mockHeaders = mock(Http2Headers.class);
-    when(mockHeaders.path()).thenReturn("/foo/extracted?query1=abc&query2=123");
+    headers.path("/foo/extracted?query1=abc&query2=123");
 
-    String path = Http2Handler.getPathFromHeaders(mockHeaders);
+    String path = Http2Handler.getPathFromHeaders(headers);
 
     assertEquals("/foo/extracted", path);
   }
 
   @Test
   public void getPathFromHeaders_withNoQueryString() {
-    Http2Headers mockHeaders = mock(Http2Headers.class);
-    when(mockHeaders.path()).thenReturn("/foo/extracted");
+    headers.path("/foo/extracted");
 
-    String path = Http2Handler.getPathFromHeaders(mockHeaders);
+    String path = Http2Handler.getPathFromHeaders(headers);
 
     assertEquals("/foo/extracted", path);
+  }
+
+  @Test
+  public void constructorRegistersListener() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+    verify(mockConnection).addListener(testHandler);
+  }
+
+  /**
+   * Tests that a XRPC_SOFT_RATE_LIMITED attribute being set will trigger a TOO_MANY_REQUESTS
+   * response.
+   */
+  @Test
+  public void testOnHeadersRead_softRateLimited() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    channel.attr(XrpcConstants.XRPC_SOFT_RATE_LIMITED).set(Boolean.TRUE);
+
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, false);
+
+    // Verify that a request was counted.
+    assertEquals(1L, requestMeter.getCount());
+    // Verify a TOO_MANY_REQUESTS response.
+    verifyResponse(
+        HttpResponseStatus.TOO_MANY_REQUESTS,
+        Optional.of(Unpooled.wrappedBuffer(XrpcConstants.RATE_LIMIT_RESPONSE)),
+        STREAM_ID);
+  }
+
+  /** Test that a headers-only request to a good path is handled appropriately. */
+  @Test
+  public void testOnHeadersRead_fullRequestGoodPath() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    headers.method("GET").path(OK_PATH);
+
+    // Call with endOfStream set to true.
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, true);
+
+    assertEquals(1L, requestMeter.getCount());
+    // Verify an OK response.
+    verifyResponse(HttpResponseStatus.OK, Optional.empty(), STREAM_ID);
+  }
+
+  /** Test that headers with data expected is handled appropriately. */
+  @Test
+  public void testOnHeadersRead_headersStreamContinuing() throws Exception {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    headers.method("GET").path(PARAM_PATH_PREFIX + "/group");
+
+    // Call with endOfStream set to false; we shouldn't see a response.
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, false);
+
+    assertEquals(1L, requestMeter.getCount());
+    verifyNoResponse();
+
+    // Verify that the request and handler were queued up.
+    XrpcRequest xrpcRequest = testHandler.requests.get(STREAM_ID);
+    assertNotNull(xrpcRequest);
+    assertEquals(headers, xrpcRequest.h2Headers());
+    assertEquals("group", xrpcRequest.variable(PARAM_NAME));
+    Handler handler = testHandler.handlers.get(STREAM_ID);
+    assertNotNull(handler);
+    assertEquals(HttpResponseStatus.OK, handler.handle(xrpcRequest).status());
+  }
+
+  /** Test that headers with too-large content-length gets a REQUEST_ENTITY_TOO_LARGE response. */
+  @Test
+  public void testOnHeadersRead_contentLengthTooLarge() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    headers.method("GET").path(OK_PATH).addLong(HttpHeaderNames.CONTENT_LENGTH, MAX_PAYLOAD + 10L);
+
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, false);
+
+    assertEquals(1L, requestMeter.getCount());
+    verifyResponse(
+        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+        Optional.of(Unpooled.wrappedBuffer(XrpcConstants.PAYLOAD_EXCEEDED_RESPONSE)),
+        STREAM_ID);
+  }
+
+  /** Test that malformed too-large content-length is ignored. */
+  @Test
+  public void testOnHeadersRead_contentLengthMalformed() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    headers.method("GET").path(OK_PATH).add(HttpHeaderNames.CONTENT_LENGTH, "abc");
+
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, true);
+
+    // Expect an OK response.
+    assertEquals(1L, requestMeter.getCount());
+    verifyResponse(HttpResponseStatus.OK, Optional.empty(), STREAM_ID);
+  }
+
+  /** Test that trailer-part headers are handled correctly. */
+  @Test
+  public void testOnHeadersRead_trailerPart() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    // Fake the initial request + handler.
+    Http2Headers initialHeaders = new DefaultHttp2Headers().method("GET").path(OK_PATH);
+    XrpcRequest fakeRequest = new XrpcRequest(initialHeaders, null, null, channel);
+    testHandler.requests.put(STREAM_ID, fakeRequest);
+    testHandler.handlers.put(STREAM_ID, OK_HANDLER);
+
+    headers.add("some-header", "some-value");
+    testHandler.onHeadersRead(mockContext, STREAM_ID, headers, 1, true);
+
+    // Expect an OK response, but DON'T expect a request count.
+    assertEquals(0L, requestMeter.getCount());
+    verifyResponse(HttpResponseStatus.OK, Optional.empty(), STREAM_ID);
+    // Assert that the request's headers were updated.
+    assertEquals("some-value", fakeRequest.h2Headers().get("some-header"));
+  }
+
+  /** Test that several data frames will be aggregated into a response. */
+  @Test
+  public void testOnDataRead_dataAggregated() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    // Create a fake request to aggregate data into.
+    XrpcRequest fakeRequest = new XrpcRequest((Http2Headers) null, null, null, channel);
+    testHandler.requests.put(STREAM_ID, fakeRequest);
+
+    // Append several data frames.
+    testHandler.onDataRead(
+        mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[] {1}), 0, false);
+    testHandler.onDataRead(
+        mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[] {2}), 0, false);
+    testHandler.onDataRead(
+        mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[] {3}), 0, false);
+
+    // Assert that the request has all the data needed.
+    assertEquals(Unpooled.wrappedBuffer(new byte[] {1, 2, 3}), fakeRequest.getData());
+  }
+
+  /** Test that end-of-stream data frames execute a handler. */
+  @Test
+  public void testOnDataRead_endOfStreamExecutes() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    // Create a fake request and handler.
+    XrpcRequest fakeRequest = new XrpcRequest((Http2Headers) null, null, null, channel);
+    testHandler.requests.put(STREAM_ID, fakeRequest);
+    testHandler.handlers.put(STREAM_ID, OK_HANDLER);
+
+    // Send a mostly-empty data frame.
+    testHandler.onDataRead(
+        mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[] {0x20}), 0, true);
+
+    // Verify an OK response.
+    assertEquals(0L, requestMeter.getCount());
+    verifyResponse(
+        HttpResponseStatus.OK, Optional.of(Unpooled.wrappedBuffer(new byte[] {0x20})), STREAM_ID);
+  }
+
+  /** Test that getting too much data will return a REQUEST_ENTITY_TOO_LARGE response. */
+  @Test
+  public void testOnDataRead_payloadTooLarge() {
+    testHandler = new Http2Handler(mockEncoder, MAX_PAYLOAD);
+
+    // Create a fake request.
+    XrpcRequest fakeRequest = new XrpcRequest((Http2Headers) null, null, null, channel);
+    testHandler.requests.put(STREAM_ID, fakeRequest);
+
+    // Start with a small payload, then add a bigger one.
+    testHandler.onDataRead(mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[10]), 0, false);
+    verifyNoResponse();
+    testHandler.onDataRead(
+        mockContext, STREAM_ID, Unpooled.wrappedBuffer(new byte[MAX_PAYLOAD - 5]), 0, true);
+
+    // Verify a TOO_MANY_REQUESTS response.
+    assertEquals(0L, requestMeter.getCount());
+    verifyResponse(
+        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+        Optional.of(Unpooled.wrappedBuffer(XrpcConstants.PAYLOAD_EXCEEDED_RESPONSE)),
+        STREAM_ID);
   }
 }


### PR DESCRIPTION
Having max payload support was critical to implementing the HTTP/2 fixes well, and is critical for DoS prevention.

Fixes #122 and fixes #128 .

This has two small commits up-front, and a larger commit in the back.

Note that this is using [`CompositeByteBuf`](https://netty.io/4.1/api/io/netty/buffer/CompositeByteBuf.html) for aggregation of data frames. This works pretty well.