### PR TITLE
Admin handler cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,25 @@ trexblue
 
 # Admin routes
 
-xrpc comes with some built in admin routes. See also [Router.java](https://github.com/Nordstrom/xrpc/blob/master/src/main/java/com/nordstrom/xrpc/server/Router.java#L262-L270) and [AdminHandlers.java](https://github.com/Nordstrom/xrpc/blob/master/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java)
+xrpc comes with some built in admin routes. See also [AdminHandlers.java](https://github.com/Nordstrom/xrpc/blob/master/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java).
+
+Admin routes are split into two groups: Informational routes, which may contain internally-sensitive
+info; and unsafe routes, which can update a running server, and should be exposed only to a subset
+of users. These can be enabled with the `admin_routes.enable_info` and `admin_routes.enable_unsafe`
+flags.
+
+Informational routes are enabled by default, while unsafe routes are disabled by default.
+
+Informational routes:
 * `/metrics` -> Returns the metrics reporters in JSON format
 * `/health` -> Expose a summary of downstream health checks
 * `/ping` -> Responds with a 200-OK status code and the text 'PONG'
 * `/ready` -> Exposes a Kubernetes or ELB specific healthcheck for liveliness
-* `/restart` -> Restart service (should be restricted to approved devs / tooling)
-* `/killkillkill` -> Shutdown service (should be restricted to approved devs / tooling)
+
+Unsafe routes:
+* `/restart` -> Restart service
+* `/killkillkill` -> Shutdown service
+* `/gc`: Request a garbage collection from the JVM
 
 # Contributing
 

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -68,7 +68,8 @@ public class XConfig {
   private final boolean consoleReporter;
   private final int slf4jReporterPollingRate;
   private final int consoleReporterPollingRate;
-  private final boolean serveAdminRoutes;
+  private final boolean adminRoutesEnableInfo;
+  private final boolean adminRoutesEnableUnsafe;
   private final boolean runBackgroundHealthChecks;
 
   private final Map<String, List<Double>> clientRateLimitOverride =
@@ -109,7 +110,8 @@ public class XConfig {
     rateLimiterPoolSize = config.getInt("rate_limiter_pool_size");
     softReqPerSec = config.getDouble("soft_req_per_sec");
     hardReqPerSec = config.getDouble("hard_req_per_sec");
-    serveAdminRoutes = config.getBoolean("serve_admin_routes");
+    adminRoutesEnableInfo = config.getBoolean("admin_routes.enable_info");
+    adminRoutesEnableUnsafe = config.getBoolean("admin_routes.enable_unsafe");
     runBackgroundHealthChecks = config.getBoolean("run_background_health_checks");
 
     // Check to see if path_to_cert and path_to_key are configured. If they are not configured,

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
@@ -267,10 +267,15 @@ public class AdminHandlers {
 
   /**
    * Registers informational admin routes. These may contain sensitive information, and should have
-   * sensible access controls imposed on them. Routes are: '/info': exposes version number, git
-   * commit number, etc '/metrics': returns the metrics reporters in JSON format '/health': exposes
-   * a summary of downstream health checks '/ping': responds with a 200-OK status code and the text
-   * 'PONG' '/ready': expose a Kubernetes or ELB specific healthcheck for liveliness
+   * sensible access controls imposed on them. Routes are:
+   *
+   * <ul>
+   *   <li>'/info': exposes version number, git commit number, etc
+   *   <li>'/metrics': returns the metrics reporters in JSON format
+   *   <li>'/health': exposes a summary of downstream health checks
+   *   <li>'/ping': responds with a 200-OK status code and the text 'PONG'
+   *   <li>'/ready': expose a Kubernetes or ELB specific healthcheck for liveliness
+   * </ul>
    */
   static void registerInfoAdminRoutes(Server server) {
     MetricsModule metricsModule = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true);
@@ -289,9 +294,13 @@ public class AdminHandlers {
 
   /**
    * Registers admin routes to which access should be tightly restricted. These mutate server state,
-   * and may not be needed in all deployment environments. Routes are: '/restart': restart service
-   * (should be restricted to approved devs / tooling) '/killkillkill': shutdown service (should be
-   * restricted to approved devs / tooling) '/gc': request a garbage collection from the JVM
+   * and may not be needed in all deployment environments. Routes are:
+   *
+   * <ul>
+   *   <li>'/restart': restart service
+   *   <li>'/killkillkill': shutdown service
+   *   <li>'/gc': request a garbage collection from the JVM
+   * </ul>
    */
   static void registerUnsafeAdminRoutes(Server server) {
     server.get("/restart", AdminHandlers.getRestartHandler(server));

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/AdminHandlers.java
@@ -19,10 +19,12 @@ package com.nordstrom.xrpc.server;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.json.MetricsModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.nordstrom.xrpc.server.http.Recipes;
 import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
 
 public class AdminHandlers {
   // CHECKSTYLE:OFF
@@ -180,7 +182,7 @@ public class AdminHandlers {
    * }</pre>
    */
   // CHECKSTYLE:ON
-  public static Handler metricsHandler(MetricRegistry metrics, ObjectMapper mapper) {
+  public static Handler getMetricsHandler(MetricRegistry metrics, ObjectMapper mapper) {
     Preconditions.checkArgument(metrics != null, "metrics may not be null");
     Preconditions.checkArgument(mapper != null, "mapper may not be null");
     return xrpcRequest ->
@@ -192,30 +194,22 @@ public class AdminHandlers {
             Recipes.ContentType.Application_Json);
   }
 
-  // TODO(JR): Need to impl a fell admin handler here
-  public static Handler adminHandler() {
-    return xrpcRequest -> Recipes.newResponseOk("TODO");
-  }
-
   /**
    * Simple ping, indicates service is up.
    *
    * @return xrpcRequest - `200 OK` with `PONG`
    */
-  public static Handler pingHandler() {
-    return xrpcRequest -> Recipes.newResponseOk("PONG");
-  }
+  public static Handler pingHandler = xrpcRequest -> Recipes.newResponseOk("PONG");
 
-  public static Handler infoHandler() {
+  /** Unimplemented; see https://github.com/Nordstrom/xrpc/issues/52 . */
+  public static Handler infoHandler = xrpcRequest -> Recipes.newResponseOk("TODO");
 
-    return xrpcRequest -> Recipes.newResponseOk("TODO");
-  }
-
-  public static Handler gcHandler() {
-    Runtime.getRuntime().gc();
-
-    return xrpcRequest -> Recipes.newResponseOk("OK");
-  }
+  /** Requests a garbage collection from the JVM. */
+  public static Handler gcHandler =
+      xrpcRequest -> {
+        Runtime.getRuntime().gc();
+        return Recipes.newResponseOk("OK");
+      };
 
   /**
    * Run registered health checks.
@@ -236,7 +230,7 @@ public class AdminHandlers {
    *
    * }</pre>
    */
-  public static Handler healthCheckHandler(
+  public static Handler getHealthCheckHandler(
       HealthCheckRegistry healthCheckRegistry, ObjectMapper mapper) {
     Preconditions.checkArgument(healthCheckRegistry != null, "healthCheckRegistry may not be null");
     Preconditions.checkArgument(mapper != null, "mapper may not be null");
@@ -257,17 +251,51 @@ public class AdminHandlers {
    *
    * @return xrpcRequest `200 OK` with `OK`
    */
-  public static Handler readyHandler() {
-    return xrpcRequest -> Recipes.newResponseOk("OK");
-  }
+  public static Handler readyHandler = xrpcRequest -> Recipes.newResponseOk("OK");
 
-  public static Handler restartHandler(Server server) {
+  /** Unimplemented. */
+  public static Handler getRestartHandler(Server server) {
     return xrpcRequest -> Recipes.newResponseOk("TODO");
   }
 
-  public static Handler killHandler(Server server) {
-    server.shutdown();
+  public static Handler getKillHandler(Server server) {
+    return xrpcRequest -> {
+      server.shutdown();
+      return Recipes.newResponseOk("OK");
+    };
+  }
 
-    return xrpcRequest -> Recipes.newResponseOk("OK");
+  /**
+   * Registers informational admin routes. These may contain sensitive information, and should have
+   * sensible access controls imposed on them. Routes are: '/info': exposes version number, git
+   * commit number, etc '/metrics': returns the metrics reporters in JSON format '/health': exposes
+   * a summary of downstream health checks '/ping': responds with a 200-OK status code and the text
+   * 'PONG' '/ready': expose a Kubernetes or ELB specific healthcheck for liveliness
+   */
+  static void registerInfoAdminRoutes(Server server) {
+    MetricsModule metricsModule = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true);
+    // TODO(jkinkead): This should optionally use a custom mapper.
+    ObjectMapper metricsMapper = new ObjectMapper().registerModule(metricsModule);
+    server.get(
+        "/metrics", AdminHandlers.getMetricsHandler(server.getMetricRegistry(), metricsMapper));
+    // TODO(jkinkead): This should optionally use a custom mapper.
+    server.get(
+        "/health",
+        AdminHandlers.getHealthCheckHandler(server.getHealthCheckRegistry(), new ObjectMapper()));
+    server.get("/info", AdminHandlers.infoHandler);
+    server.get("/ping", AdminHandlers.pingHandler);
+    server.get("/ready", AdminHandlers.readyHandler);
+  }
+
+  /**
+   * Registers admin routes to which access should be tightly restricted. These mutate server state,
+   * and may not be needed in all deployment environments. Routes are: '/restart': restart service
+   * (should be restricted to approved devs / tooling) '/killkillkill': shutdown service (should be
+   * restricted to approved devs / tooling) '/gc': request a garbage collection from the JVM
+   */
+  static void registerUnsafeAdminRoutes(Server server) {
+    server.get("/restart", AdminHandlers.getRestartHandler(server));
+    server.get("/killkillkill", AdminHandlers.getKillHandler(server));
+    server.get("/gc", AdminHandlers.gcHandler);
   }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.json.MetricsModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nordstrom.xrpc.XConfig;
 import com.nordstrom.xrpc.server.tls.Tls;
@@ -50,7 +49,7 @@ public class Server implements Routes {
   private final Tls tls;
   private final XrpcConnectionContext.Builder contextBuilder;
 
-  private final MetricRegistry metricRegistry = new MetricRegistry();
+  @Getter private final MetricRegistry metricRegistry = new MetricRegistry();
   @Getter private final RouteBuilder routeBuilder = new RouteBuilder();
 
   @Getter private Channel channel;
@@ -66,10 +65,6 @@ public class Server implements Routes {
     this.config = config;
     this.tls = new Tls(config.cert(), config.key());
     this.healthCheckRegistry = new HealthCheckRegistry(config.asyncHealthCheckThreadCount());
-
-    if (config.serveAdminRoutes()) {
-      addAdminRoutes();
-    }
 
     this.contextBuilder =
         XrpcConnectionContext.builder()
@@ -121,36 +116,6 @@ public class Server implements Routes {
         () -> healthCheckRegistry.runHealthChecks(workerGroup), initialDelay, delay, timeUnit);
   }
 
-  public MetricRegistry getMetricRegistry() {
-    return metricRegistry;
-  }
-
-  private void addAdminRoutes() {
-    MetricsModule metricsModule = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true);
-    ObjectMapper metricsMapper = new ObjectMapper().registerModule(metricsModule);
-    ObjectMapper healthMapper = new ObjectMapper();
-
-    /*
-    '/info' -> should expose version number, git commit number, etc
-    '/metrics' -> should return the metrics reporters in JSON format
-    '/health' -> should expose a summary of downstream health checks
-    '/ping' -> should respond with a 200-OK status code and the text 'PONG'
-    '/ready' -> should expose a Kubernetes or ELB specific healthcheck for liveliness
-    '/restart' -> restart service (should be restricted to approved devs / tooling)
-     '/killkillkill' -> shutdown service (should be restricted to approved devs / tooling)
-     */
-
-    get("/info", AdminHandlers.infoHandler());
-    get("/metrics", AdminHandlers.metricsHandler(metricRegistry, metricsMapper));
-    get("/health", AdminHandlers.healthCheckHandler(healthCheckRegistry, healthMapper));
-    get("/ping", AdminHandlers.pingHandler());
-    get("/ready", AdminHandlers.readyHandler());
-    get("/restart", AdminHandlers.restartHandler(this));
-    get("/killkillkill", AdminHandlers.killHandler(this));
-
-    get("/gc", AdminHandlers.pingHandler());
-  }
-
   /**
    * Builds an initializer that sets up the server pipeline, override this method to customize your
    * pipeline.
@@ -170,6 +135,13 @@ public class Server implements Routes {
    */
   public void listenAndServe() throws IOException {
     // Finalize the routes this serves.
+    if (config.adminRoutesEnableInfo()) {
+      AdminHandlers.registerInfoAdminRoutes(this);
+    }
+    if (config.adminRoutesEnableUnsafe()) {
+      AdminHandlers.registerUnsafeAdminRoutes(this);
+    }
+
     contextBuilder.routes(routeBuilder.compile(metricRegistry));
 
     XrpcConnectionContext ctx = contextBuilder.build();

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -3,8 +3,12 @@
 # The port to run on.
 server.port = 8080
 
-# If true, serve admin routes. See https://github.com/Nordstrom/xrpc#admin-routes .
-serve_admin_routes = true
+admin_routes = {
+  # If true, serve informational admin routes. See https://github.com/Nordstrom/xrpc#admin-routes .
+  enable_info = true
+  # If true, serve unsafe admin routes. See https://github.com/Nordstrom/xrpc#admin-routes .
+  enable_unsafe = false
+}
 
 # If true, run regular health checks in a background thread. This is useful for logging.
 run_background_health_checks = true

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/CorsTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/CorsTest.java
@@ -35,7 +35,6 @@ class CorsTest {
     config =
         ConfigFactory.load("test.conf")
             .getConfig("xrpc")
-            .withValue("serve_admin_routes", fromAnyRef(false))
             .withValue("run_background_health_checks", fromAnyRef(false));
     client = UnsafeHttp.unsafeClient();
   }


### PR DESCRIPTION
This splits the handlers into two clear categories, and disables the "unsafe" handlers by default. I don't expect people to read the fine-print on these being dangerous.

This also:
* registers the GC handler properly
* updates the shutdown handler to call `shutdown()` inside the lambda instead of on lambda creation
* prevents `this`-leakage from Server constructor by registering admin paths on serve

FYI @xjdr .