### PR TITLE
Tighten up overridden API for Http2Handler.

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
@@ -27,8 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Http2HandlerBuilder
-    extends AbstractHttp2ConnectionHandlerBuilder<
-        Http2HandlerBuilder.ConnectionHandler, Http2HandlerBuilder> {
+    extends AbstractHttp2ConnectionHandlerBuilder<Http2ConnectionHandler, Http2HandlerBuilder> {
 
   private static final String FRAME_LOGGER_NAME = Http2HandlerBuilder.class.getName() + ".frames";
   /** Logger to query for configuration for HTTP2 frame logging. */
@@ -41,12 +40,12 @@ public final class Http2HandlerBuilder
   }
 
   @Override
-  public ConnectionHandler build() {
+  public Http2ConnectionHandler build() {
     return super.build();
   }
 
   @Override
-  protected ConnectionHandler build(
+  protected Http2ConnectionHandler build(
       Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
@@ -58,7 +57,7 @@ public final class Http2HandlerBuilder
   }
 
   /** Trivial extension of Http2ConnectionHandler to expose a public constructor. */
-  public static class ConnectionHandler extends Http2ConnectionHandler {
+  private static class ConnectionHandler extends Http2ConnectionHandler {
     ConnectionHandler(
         Http2ConnectionDecoder decoder,
         Http2ConnectionEncoder encoder,

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Http2HandlerBuilder.java
@@ -19,6 +19,7 @@ package com.nordstrom.xrpc.server;
 import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LogLevel;
@@ -26,7 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class Http2HandlerBuilder
-    extends AbstractHttp2ConnectionHandlerBuilder<Http2Handler, Http2HandlerBuilder> {
+    extends AbstractHttp2ConnectionHandlerBuilder<
+        Http2HandlerBuilder.ConnectionHandler, Http2HandlerBuilder> {
 
   private static final String FRAME_LOGGER_NAME = Http2HandlerBuilder.class.getName() + ".frames";
   /** Logger to query for configuration for HTTP2 frame logging. */
@@ -39,17 +41,29 @@ public final class Http2HandlerBuilder
   }
 
   @Override
-  public Http2Handler build() {
+  public ConnectionHandler build() {
     return super.build();
   }
 
   @Override
-  protected Http2Handler build(
+  protected ConnectionHandler build(
       Http2ConnectionDecoder decoder,
       Http2ConnectionEncoder encoder,
       Http2Settings initialSettings) {
-    Http2Handler handler = new Http2Handler(decoder, encoder, initialSettings);
-    frameListener(handler);
+
+    decoder.frameListener(new Http2Handler(encoder));
+
+    ConnectionHandler handler = new ConnectionHandler(decoder, encoder, initialSettings);
     return handler;
+  }
+
+  /** Trivial extension of Http2ConnectionHandler to expose a public constructor. */
+  public static class ConnectionHandler extends Http2ConnectionHandler {
+    ConnectionHandler(
+        Http2ConnectionDecoder decoder,
+        Http2ConnectionEncoder encoder,
+        Http2Settings initialSettings) {
+      super(decoder, encoder, initialSettings);
+    }
   }
 }


### PR DESCRIPTION
This also marks requests coming in more correctly. I'll fix the TODO I added in a future PR, since it relies on stream ID knowledge.

As best I could tell, there was no reason we were extending `Http2ConnectionHandler`.

Some notes:
- `channelActive` was never being called, and the `mark()` there was in the wrong place anyway.
- `exceptionCaught` was never being called, either, even when exceptions were thrown. It's possible the call to `super.exceptionCaught` was bypassing the rest of the function; either way, we should have a single pipeline-level exception handler, not an HTTP2-specific one.
- overriding `userEventTriggered` with a no-op was probably an error.