### PR TITLE
Adds benchmarking

### DIFF
--- a/xrpc/build.gradle
+++ b/xrpc/build.gradle
@@ -12,6 +12,7 @@ plugins {
   id 'com.github.sherter.google-java-format' version '0.6'
   id 'net.researchgate.release' version '2.4.0'
   id 'com.github.spotbugs' version '1.6.0'
+  id 'me.champeau.gradle.jmh' version '0.4.4'
 }
 
 release {
@@ -82,6 +83,8 @@ dependencies {
   runtimeOnly 'ch.qos.logback:logback-classic:1.1.7'
   runtimeOnly 'ch.qos.logback:logback-core:1.1.7'
   runtimeOnly 'org.codehaus.groovy:groovy-all:2.4.1'
+  jmh 'ch.qos.logback:logback-core:1.1.7'
+  jmh 'ch.qos.logback:logback-classic:1.1.7'
 }
 
 // Run with the latest checkstyle version. Required for our checkstyle.xml.

--- a/xrpc/src/jmh/java/com/nordstrom/xrpc/server/JmhCompiledRoutesBenchmark.java
+++ b/xrpc/src/jmh/java/com/nordstrom/xrpc/server/JmhCompiledRoutesBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.server;
+
+import com.codahale.metrics.MetricRegistry;
+import io.netty.handler.codec.http.HttpMethod;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class JmhCompiledRoutesBenchmark {
+  CompiledRoutes compiledRoutes;
+
+  @Setup
+  public void setupRouter() {
+    Handler handler = request -> null;
+    MetricRegistry metricRegistry = new MetricRegistry();
+    RouteBuilder routes = new RouteBuilder();
+    routes.get("/foo", handler);
+    compiledRoutes = routes.compile(metricRegistry);
+  }
+
+  @BenchmarkMode({Mode.AverageTime, Mode.Throughput})
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Benchmark
+  public void basicMatch() throws IOException {
+    compiledRoutes.match("/foo", HttpMethod.GET);
+  }
+}

--- a/xrpc/src/jmh/resources/benchmark.conf
+++ b/xrpc/src/jmh/resources/benchmark.conf
@@ -1,0 +1,4 @@
+# This file/directory is to prevent the following warning from occurring during the gradle
+# Task :xrpc:jmhCompileGeneratedClasses
+# warning: [path] bad path element "/Users/x3iu/source/Nordstrom/xrpc/xrpc/build/resources/jmh":
+#   no such file or directory


### PR DESCRIPTION
* Adds JMH plugin
* Adds a simple benchmark for the CompiledRoutes.match method

Benchmarks can be run using `./gradlew clean jmh`
This first benchmark takes about 15 minutes to run and give an output similar to
the following, calculating the average time and throughput for the match method:

```
// Run complete. Total time: 00:13:47

Benchmark              Mode  Cnt  Score   Error   Units
JmhRouter.basicMatch  thrpt  200  9.105 ± 0.409  ops/us
JmhRouter.basicMatch   avgt  200  0.127 ± 0.011   us/op
```