### PR TITLE
Add proto encoding

### DIFF
--- a/xrpc/build.gradle
+++ b/xrpc/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
     classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
   }
 }
@@ -25,6 +26,7 @@ release {
 }
 
 apply plugin: 'java'
+apply plugin: 'com.google.protobuf'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'checkstyle'
@@ -45,7 +47,7 @@ tasks.withType(JavaCompile) {
     // the compiler so that the definition works).
     options.compilerArgs += [
         '-XDignore.symbol.file',
-        '-Xlint:auxiliaryclass,cast,classfile,deprecation,dep-ann,divzero,empty,fallthrough,' +
+        '-Xlint:auxiliaryclass,classfile,deprecation,dep-ann,divzero,empty,fallthrough,' +
             'finally,options,overloads,overrides,path,rawtypes,static,try,unchecked,varargs',
         '-parameters',
         '-Werror']
@@ -65,6 +67,8 @@ dependencies {
   compile 'com.squareup.okio:okio:1.13.0'
   compile 'com.typesafe:config:1.3.1'
   compile 'com.xjeffrose:xio:0.13.0'
+  compile 'com.google.protobuf:protobuf-java:3.0.0'
+  compile 'com.google.protobuf:protobuf-java-util:3.0.0'
   compile 'io.dropwizard.metrics:metrics-core:3.2.5'
   compile 'io.dropwizard.metrics:metrics-healthchecks:3.2.5'
   compile 'io.dropwizard.metrics:metrics-json:3.2.5'
@@ -91,6 +95,14 @@ dependencies {
   jmh 'ch.qos.logback:logback-classic:1.1.7'
 }
 
+sourceSets {
+  test {
+    java {
+      srcDirs 'build/generated/source/proto/test/java'
+    }
+  }
+}
+
 // Run with the latest checkstyle version. Required for our checkstyle.xml.
 checkstyle {
   toolVersion '8.3'
@@ -108,6 +120,15 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
     html.enabled = true
   }
 }
+
+// Configure protobuf build.
+protobuf {
+  // Configure the protoc executable to use the official distribution.
+  protoc {
+    artifact = 'com.google.protobuf:protoc:3.0.0'
+  }
+}
+
 
 // Add Javadoc + sources jars to artifacts list.
 task javadocJar(type: Jar) {

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XrpcConstants.java
@@ -38,4 +38,5 @@ public class XrpcConstants {
       "Internal Server Error".getBytes(DEFAULT_CHARSET);
   public static final AttributeKey<Boolean> IP_WHITE_LIST = AttributeKey.valueOf("IpWhiteList");
   public static final AttributeKey<Boolean> IP_BLACK_LIST = AttributeKey.valueOf("IpBlackList");
+  public static final String PROTO_CONTENT_TYPE = "application/protobuf";
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/Decoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/Decoder.java
@@ -18,6 +18,8 @@ package com.nordstrom.xrpc.encoding;
 
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /** Interface for decoding a request ByteBuf into Object. */
 public interface Decoder extends MediaTypeCodec {
@@ -30,4 +32,35 @@ public interface Decoder extends MediaTypeCodec {
    * @return object of type clazz
    */
   <T> T decode(ByteBuf body, CharSequence contentType, Class<T> clazz) throws IOException;
+
+  /**
+   * Invoke a static method on the target class for decoding. This is used as an intermediate step
+   * for decoding.
+   *
+   * @param clazz target Class
+   * @param methodName name of method to invoke
+   * @param types array of method argument types
+   * @param args array of arguments to pass into the method
+   * @param <InT> target Class type
+   * @param <OutT> return type of invoked method
+   * @return result of method invocation
+   */
+  @SuppressWarnings("unchecked")
+  default <InT, OutT> OutT invoke(
+      Class<InT> clazz, String methodName, Class<?>[] types, Object[] args) {
+    try {
+      // TODO (AD): add method memoization
+      Method method = clazz.getMethod(methodName, types);
+      // TODO (AD): for now we suppress unchecked cast warning.  should fix this.
+      return (OutT) method.invoke(null, args);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new IllegalArgumentException(
+          String.format("%s is not a valid Proto class: %s", clazz.getName(), e.getMessage()));
+    } catch (InvocationTargetException te) {
+      throw new RuntimeException(
+          String.format(
+              "Error decoding into %s: %s", clazz.getName(), te.getTargetException().getMessage()),
+          te.getTargetException());
+    }
+  }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/JsonEncoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/JsonEncoder.java
@@ -18,6 +18,8 @@ package com.nordstrom.xrpc.encoding;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -27,7 +29,7 @@ import java.nio.charset.Charset;
 import lombok.AllArgsConstructor;
 
 /**
- * An Encoder that encodes an object to ByteBuf in JSON format.
+ * Encoder that encodes an object to ByteBuf in JSON format.
  *
  * <p>Currently this encoder uses Jackson ObjectMapper to encode, but eventually will use
  * configurable JSON encode provider.
@@ -39,7 +41,9 @@ public class JsonEncoder implements Encoder {
       ImmutableSet.copyOf(new String[] {"UTF-8", "UTF-16", "UTF-32"});
 
   private final ObjectMapper mapper;
+  private final JsonFormat.Printer printer;
 
+  /** Media type this encoder supports. */
   public CharSequence mediaType() {
     return HttpHeaderValues.APPLICATION_JSON;
   }
@@ -56,7 +60,12 @@ public class JsonEncoder implements Encoder {
   public ByteBuf encode(ByteBuf buf, CharSequence acceptCharset, Object object) throws IOException {
     try (OutputStreamWriter writer =
         new OutputStreamWriter(new ByteBufOutputStream(buf), charset(acceptCharset))) {
-      mapper.writeValue(writer, object);
+      if (object instanceof MessageOrBuilder) {
+        String json = printer.print((MessageOrBuilder) object);
+        writer.write(json);
+      } else {
+        mapper.writeValue(writer, object);
+      }
       return buf;
     }
   }
@@ -64,7 +73,7 @@ public class JsonEncoder implements Encoder {
   @Override
   public Charset charset(CharSequence acceptCharset) {
     if (acceptCharset == null) {
-      return TextEncoder.DEFAULT_CHARSET;
+      return DEFAULT_CHARSET;
     }
     String[] charsets = CHARSET_DELIMITER.split(acceptCharset);
     for (String charset : charsets) {
@@ -73,6 +82,6 @@ public class JsonEncoder implements Encoder {
         return Charset.forName(charsetUpper);
       }
     }
-    return TextEncoder.DEFAULT_CHARSET;
+    return DEFAULT_CHARSET;
   }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/MediaTypeCodecs.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/MediaTypeCodecs.java
@@ -8,9 +8,10 @@ import lombok.experimental.Accessors;
 
 /**
  * Base collection of MediaTypable objects. Consolidates the logic of lookup up an item based on
- * CharSequence mediaType. It also provides a defaultValue and appropriate getOrDefault.
+ * CharSequence mediaTypes. It also provides a defaultValue and appropriate getOrDefault.
  *
- * <p>Intended for a small set of objects as lookup is O(N).
+ * <p>Intended for a small set of objects as lookup is O(N) where N = Number of supported Media
+ * Types.
  *
  * @param <T> MediaTypeCodec item type
  */

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoDecoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoDecoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.encoding;
+
+import com.nordstrom.xrpc.XrpcConstants;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Decoder that decodes a protobuf ByteBuf to an object.
+ *
+ * <p>Currently this decoder uses Proto 3 generated classes to decode.
+ */
+@Slf4j
+public class ProtoDecoder implements Decoder {
+  /** Content type this decoder supports. */
+  @Override
+  public CharSequence mediaType() {
+    return XrpcConstants.PROTO_CONTENT_TYPE;
+  }
+
+  /**
+   * Decode a ByteBuf body from protobuf format to an object of designated Class type.
+   *
+   * @param body current http request
+   * @param clazz target class for decoding
+   * @return object of type clazz
+   */
+  @Override
+  public <T> T decode(ByteBuf body, CharSequence contentType, Class<T> clazz) throws IOException {
+    // TODO (AD): given a Content-Type of application/protobuf; proto=org.some.Message,
+    // we currently ignore the 2nd part, but should at least validate it in the future.
+    try (ByteBufInputStream stream = new ByteBufInputStream(body)) {
+      return invoke(clazz, "parseFrom", new Class<?>[] {InputStream.class}, new Object[] {stream});
+    }
+  }
+}

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoEncoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoEncoder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.encoding;
+
+import com.google.protobuf.MessageLite;
+import com.nordstrom.xrpc.XrpcConstants;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import java.io.IOException;
+
+/**
+ * Encoder that encodes an object to ByteBuf in protobuf format.
+ *
+ * <p>Currently this encoder uses Proto 3 generated classes to encode
+ */
+public class ProtoEncoder implements Encoder {
+  /** Media type this decoder supports. */
+  @Override
+  public CharSequence mediaType() {
+    // TODO (AD): since this is not the official content type of protobuf,
+    // consider supporting other types used in the wild.
+    return XrpcConstants.PROTO_CONTENT_TYPE;
+  }
+
+  /**
+   * Encode a response object to protobuf format for the HttpResponse.
+   *
+   * @param buf target byte buffer for encoding
+   * @param acceptCharset Accept-Charset header
+   * @param object object to encode
+   * @return ByteBuf representing protobuf formatted bytes
+   */
+  @Override
+  public ByteBuf encode(ByteBuf buf, CharSequence acceptCharset, Object object) throws IOException {
+    if (!(object instanceof MessageLite)) {
+      throw new IllegalArgumentException("object must be instance of MessageLite");
+    }
+    MessageLite msg = (MessageLite) object;
+    try (ByteBufOutputStream stream = new ByteBufOutputStream(buf)) {
+      msg.writeTo(stream);
+      return buf;
+    }
+  }
+}

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/http/Recipes.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/http/Recipes.java
@@ -112,7 +112,7 @@ public final class Recipes {
    * following key and value: "access-control-allow-origin", "http://foo.example"
    *
    * <p>If content type or content length are passed in as custom headers, they will be ignored.
-   * Instead, content type will be as specified by the parameter mediaType and content length will
+   * Instead, content type will be as specified by the parameter mediaTypes and content length will
    * be the length of the parameter contentLength.
    */
   public static FullHttpResponse newResponse(

--- a/xrpc/src/test/java/com/nordstrom/xrpc/encoding/EncodersTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/encoding/EncodersTest.java
@@ -3,6 +3,7 @@ package com.nordstrom.xrpc.encoding;
 import static org.junit.Assert.assertSame;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
 import io.netty.buffer.ByteBuf;
 import java.beans.ConstructorProperties;
 import java.io.IOException;
@@ -20,7 +21,8 @@ class EncodersTest {
     }
   }
 
-  private JsonEncoder jsonEncoder = new JsonEncoder(new ObjectMapper());
+  private JsonEncoder jsonEncoder =
+      new JsonEncoder(new ObjectMapper(), JsonFormat.printer().omittingInsignificantWhitespace());
   private Encoder fooBarEncoder =
       new Encoder() {
         @Override

--- a/xrpc/src/test/java/com/nordstrom/xrpc/encoding/JsonEncoderTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/encoding/JsonEncoderTest.java
@@ -3,6 +3,7 @@ package com.nordstrom.xrpc.encoding;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
 import io.netty.buffer.Unpooled;
 import java.beans.ConstructorProperties;
 import java.io.IOException;
@@ -20,7 +21,8 @@ class JsonEncoderTest {
     }
   }
 
-  private JsonEncoder jsonEncoder = new JsonEncoder(new ObjectMapper());
+  private JsonEncoder jsonEncoder =
+      new JsonEncoder(new ObjectMapper(), JsonFormat.printer().omittingInsignificantWhitespace());
 
   @Test
   void testEncodeJsonUtf16() throws IOException {

--- a/xrpc/src/test/java/com/nordstrom/xrpc/encoding/ProtoDecoderTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/encoding/ProtoDecoderTest.java
@@ -1,0 +1,19 @@
+package com.nordstrom.xrpc.encoding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.nordstrom.xrpc.encoding.dino.proto.Dino;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ProtoDecoderTest {
+  private ProtoDecoder decoder = new ProtoDecoder();
+  private Dino dino = Dino.newBuilder().setName("test-name").setFavColor("test-color").build();
+
+  @Test
+  void testDecode() throws IOException {
+    Dino result = decoder.decode(Unpooled.wrappedBuffer(dino.toByteArray()), "", Dino.class);
+    assertEquals(dino, result);
+  }
+}

--- a/xrpc/src/test/java/com/nordstrom/xrpc/encoding/ProtoEncoderTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/encoding/ProtoEncoderTest.java
@@ -1,0 +1,26 @@
+package com.nordstrom.xrpc.encoding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.nordstrom.xrpc.encoding.dino.proto.Dino;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class ProtoEncoderTest {
+  private ProtoEncoder encoder = new ProtoEncoder();
+  private Dino dino = Dino.newBuilder().setName("test-name").setFavColor("test-color").build();
+
+  @Test
+  void testEncode() throws IOException {
+    ByteBuf buf = encoder.encode(Unpooled.directBuffer(), "", dino);
+    assertEquals(dino, Dino.parseFrom(bufBytes(buf)));
+  }
+
+  private byte[] bufBytes(ByteBuf buf) {
+    byte[] bytes = new byte[buf.readableBytes()];
+    buf.readBytes(bytes);
+    return bytes;
+  }
+}

--- a/xrpc/src/test/proto/dino.proto
+++ b/xrpc/src/test/proto/dino.proto
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package nordstrom.dino;
+
+option java_package = "com.nordstrom.xrpc.encoding.dino.proto";
+option java_multiple_files = true;
+
+// The Dino Object definition.
+message Dino {
+  // Name of the Person
+  string name = 1;
+
+  // Fav Color
+  string fav_color = 2;
+}


### PR DESCRIPTION
- ProtoEncoder - supports encoding proto based on Accept header
- ProtoDecoder - supports decoding proto based on Content-Type header
- Modified JsonEncoder to support Json encoding for Proto-based objects
- Modified JsonDecoder to support Json decoding for Proto-based classes
- Modified Decoder to support helper for Class static method invocation.
- Unit Tests.