### PR TITLE
Work around for travis ci bintray deployer auth issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_deploy:
   - ./gradlew generatePomFileForXrpcMavenPublication publishToMavenLocal
 deploy:
   - provider: bintray
+    edge:
+      branch: v1.8.47
     skip_cleanup: true
     file: .travis/bintray_descriptor.json
     user: $BINTRAY_USERNAME


### PR DESCRIPTION
*Dpl* is the deploy tool used for continuous deployment. As per this Github issue travis-ci/travis-ci#9314, there are some problems with the latest version, 1.9; the fix now is to use an older version - v1.8.47.
A permanent solution is being worked out, as seen in the above link.