### PR TITLE
make NotFoundException constructor public

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/NotFoundException.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/NotFoundException.java
@@ -26,7 +26,7 @@ public class NotFoundException extends HttpResponseException {
    *
    * @param message Error message
    */
-  protected NotFoundException(String message) {
+  public NotFoundException(String message) {
     super(STATUS_CODE, ERROR_CODE, message);
   }
 


### PR DESCRIPTION
Makes NotFoundException constructor public so it can be thrown from handlers.