### PR TITLE
Add service iface for proto server generation

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Routes.java
@@ -160,4 +160,14 @@ public interface Routes extends Iterable<Route> {
     }
     return this;
   }
+
+  /**
+   * Adds all routes from a Service to this route collection.
+   *
+   * @param service add routes from this Service
+   * @return this builder
+   */
+  default Routes addService(Service service) {
+    return addRoutes(service.routes());
+  }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Service.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Service.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Nordstrom, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nordstrom.xrpc.server;
+
+/** Interface for proto generated server code. */
+public interface Service {
+  /** Get all routes for this service. */
+  Routes routes();
+}


### PR DESCRIPTION
This adds a simple Service interface that can be added to routes.   The proto generated java will implement this interface.