### PR TITLE
Don't allow null response bodies to be serialized.

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/JsonEncoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/JsonEncoder.java
@@ -61,14 +61,12 @@ public class JsonEncoder implements Encoder {
     try (OutputStreamWriter writer =
         new OutputStreamWriter(new ByteBufOutputStream(buf), charset(acceptCharset))) {
       if (object instanceof MessageOrBuilder) {
-        // Encode object of proto generated Class
+        // Encode proto using its defined serialization.
         String json = printer.print((MessageOrBuilder) object);
         writer.write(json);
       } else {
-        // Encode POJO
-        if (object != null) {
-          mapper.writeValue(writer, object);
-        }
+        // Encode POJO using Jackson.
+        mapper.writeValue(writer, object);
       }
       return buf;
     }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoEncoder.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/encoding/ProtoEncoder.java
@@ -46,9 +46,6 @@ public class ProtoEncoder implements Encoder {
    */
   @Override
   public ByteBuf encode(ByteBuf buf, CharSequence acceptCharset, Object object) throws IOException {
-    if (object == null) {
-      return buf;
-    }
     if (!(object instanceof MessageLite)) {
       throw new IllegalArgumentException(
           String.format("%s does not extend from MessageLite", object.getClass().getName()));

--- a/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/DefaultHttpResponseException.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/DefaultHttpResponseException.java
@@ -1,29 +1,21 @@
 package com.nordstrom.xrpc.exceptions;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.nordstrom.xrpc.exceptions.proto.Error;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
-@Accessors(fluent = true)
+/** Base exception for responses using a simple string error code in the response. */
 public class DefaultHttpResponseException extends HttpResponseException {
-  @Getter private final String errorCode;
+  private final String errorCode;
 
   public DefaultHttpResponseException(int statusCode, String errorCode, String message) {
-    super(
-        statusCode,
-        Error.newBuilder().setMessage(message).setErrorCode(errorCode).build(),
-        message);
-    this.errorCode = errorCode;
+    this(statusCode, errorCode, message, null);
   }
 
   public DefaultHttpResponseException(
       int statusCode, String errorCode, String message, Throwable cause) {
-    super(
-        statusCode,
-        Error.newBuilder().setMessage(message).setErrorCode(errorCode).build(),
-        message,
-        cause);
+    super(statusCode, buildError(errorCode, message), message, cause);
+
     this.errorCode = errorCode;
   }
 
@@ -35,12 +27,23 @@ public class DefaultHttpResponseException extends HttpResponseException {
             .append(": [")
             .append(statusCode())
             .append("] ")
-            .append(errorCode());
+            .append(errorCode);
 
     String message = getLocalizedMessage();
     if (!Strings.isNullOrEmpty(message)) {
       buffer.append(": ").append(message);
     }
     return buffer.toString();
+  }
+
+  /**
+   * Builds an error message from the given fields.
+   *
+   * @throws IllegalArgumentException if errorCode is empty or null
+   */
+  private static Error buildError(String errorCode, String message) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(errorCode), "errorCode must be non-null and non-empty");
+    return Error.newBuilder().setErrorCode(errorCode).setMessage(message).build();
   }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/DefaultHttpResponseException.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/DefaultHttpResponseException.java
@@ -20,6 +20,12 @@ public class DefaultHttpResponseException extends HttpResponseException {
   }
 
   @Override
+  public Error error() {
+    // Workaround for the fact that we can't make HttpResponseException generic.
+    return (Error) super.error();
+  }
+
+  @Override
   public String toString() {
     StringBuilder buffer =
         new StringBuilder()

--- a/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/HttpResponseException.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/exceptions/HttpResponseException.java
@@ -23,49 +23,41 @@ import lombok.experimental.Accessors;
 /** Base exception for Exceptions that are meant to convert to HTTP Responses. */
 @Accessors(fluent = true)
 public class HttpResponseException extends RuntimeException {
-  /** HTTP Status Code. */
+  /** HTTP status code. */
   @Getter private final int statusCode;
 
-  /** Error object . */
-  @Getter private final Object errorObject;
+  /** Error object to serialize as the response body. */
+  @Getter private final Object error;
 
   /**
-   * Construct HttpResponseException with a cause.
+   * Construct HttpResponseException with an empty cause.
    *
-   * @param statusCode HTTP Status Code
-   * @param error Error object.
-   * @param message Error message.
+   * @param statusCode HTTP status code to send with the response
+   * @param error error object, serialized with the response
+   * @param message exception message. This is NOT serialized with the respone, and is only used for
+   *     logging.
+   * @throws IllegalArgumentException if statusCode is outside the valid range, or if error is null
    */
   public HttpResponseException(int statusCode, Object error, String message) {
-    super(message);
-    Preconditions.checkArgument(
-        statusCode >= 200 && statusCode <= 527, "statusCode should be >= 200 && <= 527");
-    this.statusCode = statusCode;
-    this.errorObject = error;
+    this(statusCode, error, message, null);
   }
 
   /**
    * Construct HttpResponseException with a cause.
    *
-   * @param statusCode HTTP Status Code
-   * @param error Error object.
-   * @param message Error message.
-   * @param cause The Throwable that caused this error.
+   * @param statusCode HTTP status code to send with the response
+   * @param error error object, serialized with the response
+   * @param message exception message. This is NOT serialized with the respone, and is only used for
+   *     logging.
+   * @param cause the cause of the exception, for logging. May be null.
+   * @throws IllegalArgumentException if statusCode is outside the valid range, or if error is null
    */
   public HttpResponseException(int statusCode, Object error, String message, Throwable cause) {
     super(message, cause);
     Preconditions.checkArgument(
-        statusCode >= 200 && statusCode <= 527, "statusCode should be >= 200 && <= 527");
+        statusCode >= 200 && statusCode <= 527, "statusCode must be >= 200 && <= 527");
+    Preconditions.checkArgument(error != null, "error must be non-null");
     this.statusCode = statusCode;
-    this.errorObject = error;
-  }
-
-  /**
-   * Get the error response for this exception. This is used for response encoding.
-   *
-   * @return Error object based on this exception.
-   */
-  public Object error() {
-    return errorObject;
+    this.error = error;
   }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/ResponseFactory.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/ResponseFactory.java
@@ -3,6 +3,7 @@ package com.nordstrom.xrpc.server;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 
+import com.google.common.base.Preconditions;
 import com.nordstrom.xrpc.XrpcConstants;
 import com.nordstrom.xrpc.encoding.Encoder;
 import com.nordstrom.xrpc.exceptions.HttpResponseException;
@@ -106,8 +107,10 @@ public interface ResponseFactory {
    * @param body body object to be encoded based on Content Negotiation
    * @param <T> type of body object
    * @throws IOException if encoding errors occur
+   * @throws IllegalArgumentException if the provided body is null
    */
   default <T> HttpResponse createResponse(HttpResponseStatus status, T body) throws IOException {
+    Preconditions.checkArgument(body != null, "null body passed in to createResponse");
     final Encoder encoder =
         request().connectionContext().encoders().acceptedEncoder(request().acceptHeader());
     ByteBuf buf = request().byteBuf();


### PR DESCRIPTION
This fixes a behavior change introduced in #194. There are response builder helpers that don't take a body, and should be used for an empty response body. A null body probably indicates a programming error.

Clean up a exception construction slightly, and add back in preconditions checks which were removed. This forces the user to provide an error message, which is what we want (information-free errors are not great).