### PR TITLE
Allow CRLF in raw certificate string

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
@@ -16,7 +16,8 @@
 
 package com.nordstrom.xrpc.server.tls;
 
-import com.nordstrom.xrpc.XrpcConstants;
+import static com.nordstrom.xrpc.server.tls.X509CertificateGenerator.parseX509Certificates;
+
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
@@ -31,7 +32,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.KeyStore;
@@ -42,9 +42,6 @@ import java.security.PrivateKey;
 import java.security.SignatureException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.ArrayList;
-import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
 import lombok.extern.slf4j.Slf4j;
 
@@ -181,30 +178,5 @@ public class Tls {
     }
 
     return null;
-  }
-
-  private java.security.cert.X509Certificate[] parseX509Certificates(String rawCertString)
-      throws CertificateException {
-    java.security.cert.X509Certificate[] chain;
-    final List<java.security.cert.X509Certificate> certList = new ArrayList<>();
-    String[] certs = rawCertString.split("-----END CERTIFICATE-----\n");
-
-    for (String cert : certs) {
-      CertificateFactory cf = CertificateFactory.getInstance("X.509");
-      java.security.cert.X509Certificate x509Certificate =
-          (java.security.cert.X509Certificate)
-              cf.generateCertificate(
-                  new ByteArrayInputStream(
-                      (cert + "-----END CERTIFICATE-----\n")
-                          .getBytes(XrpcConstants.DEFAULT_CHARSET)));
-      certList.add(x509Certificate);
-    }
-
-    chain = new java.security.cert.X509Certificate[certList.size()];
-
-    for (int i = 0; i < certList.size(); i++) {
-      chain[i] = certList.get(i);
-    }
-    return chain;
   }
 }

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/X509CertificateGenerator.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/X509CertificateGenerator.java
@@ -17,6 +17,7 @@
 package com.nordstrom.xrpc.server.tls;
 
 import com.nordstrom.xrpc.XrpcConstants;
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,7 +38,9 @@ import java.security.cert.CertificateFactory;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerValue;
@@ -172,6 +175,31 @@ public final class X509CertificateGenerator {
         }
       }
     }
+  }
+
+  public static java.security.cert.X509Certificate[] parseX509Certificates(String rawCertString)
+      throws CertificateException {
+    java.security.cert.X509Certificate[] chain;
+    final List<java.security.cert.X509Certificate> certList = new ArrayList<>();
+    String[] certs = rawCertString.split("-----END CERTIFICATE-----\n");
+
+    for (String cert : certs) {
+      CertificateFactory cf = CertificateFactory.getInstance("X.509");
+      java.security.cert.X509Certificate x509Certificate =
+          (java.security.cert.X509Certificate)
+              cf.generateCertificate(
+                  new ByteArrayInputStream(
+                      (cert + "-----END CERTIFICATE-----\n")
+                          .getBytes(XrpcConstants.DEFAULT_CHARSET)));
+      certList.add(x509Certificate);
+    }
+
+    chain = new java.security.cert.X509Certificate[certList.size()];
+
+    for (int i = 0; i < certList.size(); i++) {
+      chain[i] = certList.get(i);
+    }
+    return chain;
   }
 
   public static class DerKeySpec {

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/X509CertificateGenerator.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/X509CertificateGenerator.java
@@ -181,6 +181,7 @@ public final class X509CertificateGenerator {
       throws CertificateException {
     java.security.cert.X509Certificate[] chain;
     final List<java.security.cert.X509Certificate> certList = new ArrayList<>();
+    rawCertString = rawCertString.replace("\r\n", "\n");
     String[] certs = rawCertString.split("-----END CERTIFICATE-----\n");
 
     for (String cert : certs) {

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 class X509CertificateGeneratorTest {
@@ -22,6 +21,16 @@ class X509CertificateGeneratorTest {
   public void parseX509CertificateGeneratorShouldAcceptTwoCertificates()
       throws CertificateException {
     String cert = getStandardCert() + "\n" + getStandardCert() + "\n";
+
+    X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
+
+    assertEquals(2, certificates.length);
+  }
+
+  @Test
+  public void parseX509CertificateGeneratorShouldAcceptTwoCertificatesDelimitedByCrlf()
+      throws CertificateException {
+    String cert = getStandardCert() + "\r\n" + getStandardCert() + "\n";
 
     X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
 

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
@@ -10,37 +10,50 @@ class X509CertificateGeneratorTest {
   @Test
   public void parseX509CertificateGeneratorShouldAcceptOneCertificate()
       throws CertificateException {
-    String cert =
-        "-----BEGIN CERTIFICATE-----\n"
-            + "MIIElDCCA3ygAwIBAgIQAf2j627KdciIQ4tyS8+8kTANBgkqhkiG9w0BAQsFADBh\n"
-            + "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n"
-            + "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n"
-            + "QTAeFw0xMzAzMDgxMjAwMDBaFw0yMzAzMDgxMjAwMDBaME0xCzAJBgNVBAYTAlVT\n"
-            + "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxJzAlBgNVBAMTHkRpZ2lDZXJ0IFNIQTIg\n"
-            + "U2VjdXJlIFNlcnZlciBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n"
-            + "ANyuWJBNwcQwFZA1W248ghX1LFy949v/cUP6ZCWA1O4Yok3wZtAKc24RmDYXZK83\n"
-            + "nf36QYSvx6+M/hpzTc8zl5CilodTgyu5pnVILR1WN3vaMTIa16yrBvSqXUu3R0bd\n"
-            + "KpPDkC55gIDvEwRqFDu1m5K+wgdlTvza/P96rtxcflUxDOg5B6TXvi/TC2rSsd9f\n"
-            + "/ld0Uzs1gN2ujkSYs58O09rg1/RrKatEp0tYhG2SS4HD2nOLEpdIkARFdRrdNzGX\n"
-            + "kujNVA075ME/OV4uuPNcfhCOhkEAjUVmR7ChZc6gqikJTvOX6+guqw9ypzAO+sf0\n"
-            + "/RR3w6RbKFfCs/mC/bdFWJsCAwEAAaOCAVowggFWMBIGA1UdEwEB/wQIMAYBAf8C\n"
-            + "AQAwDgYDVR0PAQH/BAQDAgGGMDQGCCsGAQUFBwEBBCgwJjAkBggrBgEFBQcwAYYY\n"
-            + "aHR0cDovL29jc3AuZGlnaWNlcnQuY29tMHsGA1UdHwR0MHIwN6A1oDOGMWh0dHA6\n"
-            + "Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RDQS5jcmwwN6A1\n"
-            + "oDOGMWh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RD\n"
-            + "QS5jcmwwPQYDVR0gBDYwNDAyBgRVHSAAMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8v\n"
-            + "d3d3LmRpZ2ljZXJ0LmNvbS9DUFMwHQYDVR0OBBYEFA+AYRyCMWHVLyjnjUY4tCzh\n"
-            + "xtniMB8GA1UdIwQYMBaAFAPeUDVW0Uy7ZvCj4hsbw5eyPdFVMA0GCSqGSIb3DQEB\n"
-            + "CwUAA4IBAQAjPt9L0jFCpbZ+QlwaRMxp0Wi0XUvgBCFsS+JtzLHgl4+mUwnNqipl\n"
-            + "5TlPHoOlblyYoiQm5vuh7ZPHLgLGTUq/sELfeNqzqPlt/yGFUzZgTHbO7Djc1lGA\n"
-            + "8MXW5dRNJ2Srm8c+cftIl7gzbckTB+6WohsYFfZcTEDts8Ls/3HB40f/1LkAtDdC\n"
-            + "2iDJ6m6K7hQGrn2iWZiIqBtvLfTyyRRfJs8sjX7tN8Cp1Tm5gr8ZDOo0rwAhaPit\n"
-            + "c+LJMto4JQtV05od8GiG7S5BNO98pVAdvzr508EIDObtHopYJeS4d60tbvVS3bR0\n"
-            + "j6tJLp07kzQoH3jOlOrHvdPJbRzeXDLz\n"
-            + "-----END CERTIFICATE-----\n";
+    String cert = getStandardCert();
 
     X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
 
     assertEquals(1, certificates.length);
+  }
+
+  @Test
+  public void parseX509CertificateGeneratorShouldAcceptTwoCertificates()
+      throws CertificateException {
+    String cert = getStandardCert() + getStandardCert();
+
+    X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
+
+    assertEquals(2, certificates.length);
+  }
+
+  private String getStandardCert() {
+    return "-----BEGIN CERTIFICATE-----\n"
+        + "MIIElDCCA3ygAwIBAgIQAf2j627KdciIQ4tyS8+8kTANBgkqhkiG9w0BAQsFADBh\n"
+        + "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n"
+        + "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n"
+        + "QTAeFw0xMzAzMDgxMjAwMDBaFw0yMzAzMDgxMjAwMDBaME0xCzAJBgNVBAYTAlVT\n"
+        + "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxJzAlBgNVBAMTHkRpZ2lDZXJ0IFNIQTIg\n"
+        + "U2VjdXJlIFNlcnZlciBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n"
+        + "ANyuWJBNwcQwFZA1W248ghX1LFy949v/cUP6ZCWA1O4Yok3wZtAKc24RmDYXZK83\n"
+        + "nf36QYSvx6+M/hpzTc8zl5CilodTgyu5pnVILR1WN3vaMTIa16yrBvSqXUu3R0bd\n"
+        + "KpPDkC55gIDvEwRqFDu1m5K+wgdlTvza/P96rtxcflUxDOg5B6TXvi/TC2rSsd9f\n"
+        + "/ld0Uzs1gN2ujkSYs58O09rg1/RrKatEp0tYhG2SS4HD2nOLEpdIkARFdRrdNzGX\n"
+        + "kujNVA075ME/OV4uuPNcfhCOhkEAjUVmR7ChZc6gqikJTvOX6+guqw9ypzAO+sf0\n"
+        + "/RR3w6RbKFfCs/mC/bdFWJsCAwEAAaOCAVowggFWMBIGA1UdEwEB/wQIMAYBAf8C\n"
+        + "AQAwDgYDVR0PAQH/BAQDAgGGMDQGCCsGAQUFBwEBBCgwJjAkBggrBgEFBQcwAYYY\n"
+        + "aHR0cDovL29jc3AuZGlnaWNlcnQuY29tMHsGA1UdHwR0MHIwN6A1oDOGMWh0dHA6\n"
+        + "Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RDQS5jcmwwN6A1\n"
+        + "oDOGMWh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RD\n"
+        + "QS5jcmwwPQYDVR0gBDYwNDAyBgRVHSAAMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8v\n"
+        + "d3d3LmRpZ2ljZXJ0LmNvbS9DUFMwHQYDVR0OBBYEFA+AYRyCMWHVLyjnjUY4tCzh\n"
+        + "xtniMB8GA1UdIwQYMBaAFAPeUDVW0Uy7ZvCj4hsbw5eyPdFVMA0GCSqGSIb3DQEB\n"
+        + "CwUAA4IBAQAjPt9L0jFCpbZ+QlwaRMxp0Wi0XUvgBCFsS+JtzLHgl4+mUwnNqipl\n"
+        + "5TlPHoOlblyYoiQm5vuh7ZPHLgLGTUq/sELfeNqzqPlt/yGFUzZgTHbO7Djc1lGA\n"
+        + "8MXW5dRNJ2Srm8c+cftIl7gzbckTB+6WohsYFfZcTEDts8Ls/3HB40f/1LkAtDdC\n"
+        + "2iDJ6m6K7hQGrn2iWZiIqBtvLfTyyRRfJs8sjX7tN8Cp1Tm5gr8ZDOo0rwAhaPit\n"
+        + "c+LJMto4JQtV05od8GiG7S5BNO98pVAdvzr508EIDObtHopYJeS4d60tbvVS3bR0\n"
+        + "j6tJLp07kzQoH3jOlOrHvdPJbRzeXDLz\n"
+        + "-----END CERTIFICATE-----\n";
   }
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
@@ -4,13 +4,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 class X509CertificateGeneratorTest {
   @Test
   public void parseX509CertificateGeneratorShouldAcceptOneCertificate()
       throws CertificateException {
-    String cert = getStandardCert();
+    String cert = getStandardCert() + "\n";
 
     X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
 
@@ -20,7 +21,7 @@ class X509CertificateGeneratorTest {
   @Test
   public void parseX509CertificateGeneratorShouldAcceptTwoCertificates()
       throws CertificateException {
-    String cert = getStandardCert() + getStandardCert();
+    String cert = getStandardCert() + "\n" + getStandardCert() + "\n";
 
     X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
 
@@ -54,6 +55,6 @@ class X509CertificateGeneratorTest {
         + "2iDJ6m6K7hQGrn2iWZiIqBtvLfTyyRRfJs8sjX7tN8Cp1Tm5gr8ZDOo0rwAhaPit\n"
         + "c+LJMto4JQtV05od8GiG7S5BNO98pVAdvzr508EIDObtHopYJeS4d60tbvVS3bR0\n"
         + "j6tJLp07kzQoH3jOlOrHvdPJbRzeXDLz\n"
-        + "-----END CERTIFICATE-----\n";
+        + "-----END CERTIFICATE-----";
   }
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/server/tls/X509CertificateGeneratorTest.java
@@ -1,0 +1,46 @@
+package com.nordstrom.xrpc.server.tls;
+
+import static org.junit.Assert.assertEquals;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import org.junit.jupiter.api.Test;
+
+class X509CertificateGeneratorTest {
+  @Test
+  public void parseX509CertificateGeneratorShouldAcceptOneCertificate()
+      throws CertificateException {
+    String cert =
+        "-----BEGIN CERTIFICATE-----\n"
+            + "MIIElDCCA3ygAwIBAgIQAf2j627KdciIQ4tyS8+8kTANBgkqhkiG9w0BAQsFADBh\n"
+            + "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n"
+            + "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n"
+            + "QTAeFw0xMzAzMDgxMjAwMDBaFw0yMzAzMDgxMjAwMDBaME0xCzAJBgNVBAYTAlVT\n"
+            + "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxJzAlBgNVBAMTHkRpZ2lDZXJ0IFNIQTIg\n"
+            + "U2VjdXJlIFNlcnZlciBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n"
+            + "ANyuWJBNwcQwFZA1W248ghX1LFy949v/cUP6ZCWA1O4Yok3wZtAKc24RmDYXZK83\n"
+            + "nf36QYSvx6+M/hpzTc8zl5CilodTgyu5pnVILR1WN3vaMTIa16yrBvSqXUu3R0bd\n"
+            + "KpPDkC55gIDvEwRqFDu1m5K+wgdlTvza/P96rtxcflUxDOg5B6TXvi/TC2rSsd9f\n"
+            + "/ld0Uzs1gN2ujkSYs58O09rg1/RrKatEp0tYhG2SS4HD2nOLEpdIkARFdRrdNzGX\n"
+            + "kujNVA075ME/OV4uuPNcfhCOhkEAjUVmR7ChZc6gqikJTvOX6+guqw9ypzAO+sf0\n"
+            + "/RR3w6RbKFfCs/mC/bdFWJsCAwEAAaOCAVowggFWMBIGA1UdEwEB/wQIMAYBAf8C\n"
+            + "AQAwDgYDVR0PAQH/BAQDAgGGMDQGCCsGAQUFBwEBBCgwJjAkBggrBgEFBQcwAYYY\n"
+            + "aHR0cDovL29jc3AuZGlnaWNlcnQuY29tMHsGA1UdHwR0MHIwN6A1oDOGMWh0dHA6\n"
+            + "Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RDQS5jcmwwN6A1\n"
+            + "oDOGMWh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RD\n"
+            + "QS5jcmwwPQYDVR0gBDYwNDAyBgRVHSAAMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8v\n"
+            + "d3d3LmRpZ2ljZXJ0LmNvbS9DUFMwHQYDVR0OBBYEFA+AYRyCMWHVLyjnjUY4tCzh\n"
+            + "xtniMB8GA1UdIwQYMBaAFAPeUDVW0Uy7ZvCj4hsbw5eyPdFVMA0GCSqGSIb3DQEB\n"
+            + "CwUAA4IBAQAjPt9L0jFCpbZ+QlwaRMxp0Wi0XUvgBCFsS+JtzLHgl4+mUwnNqipl\n"
+            + "5TlPHoOlblyYoiQm5vuh7ZPHLgLGTUq/sELfeNqzqPlt/yGFUzZgTHbO7Djc1lGA\n"
+            + "8MXW5dRNJ2Srm8c+cftIl7gzbckTB+6WohsYFfZcTEDts8Ls/3HB40f/1LkAtDdC\n"
+            + "2iDJ6m6K7hQGrn2iWZiIqBtvLfTyyRRfJs8sjX7tN8Cp1Tm5gr8ZDOo0rwAhaPit\n"
+            + "c+LJMto4JQtV05od8GiG7S5BNO98pVAdvzr508EIDObtHopYJeS4d60tbvVS3bR0\n"
+            + "j6tJLp07kzQoH3jOlOrHvdPJbRzeXDLz\n"
+            + "-----END CERTIFICATE-----\n";
+
+    X509Certificate[] certificates = X509CertificateGenerator.parseX509Certificates(cert);
+
+    assertEquals(1, certificates.length);
+  }
+}


### PR DESCRIPTION
Cleans up the raw certificate string by replacing CRLFs with LFs.
This makes parsing the string a bit more permissive.

We ran into this issue while trying to manually chain certs in a file.