### PR TITLE
Enable mutual auth utilising TLS config

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -151,7 +151,7 @@ public class XConfig {
   }
 
   private TlsConfig buildTlsConfig(Config config) {
-    Config tlsConf = config.getConfig("tls_config");
+    Config tlsConf = config.getConfig("tls");
     ClientAuth clientAuth = getEnum(tlsConf, "client_auth", ClientAuth.class, ClientAuth.NONE);
     String certificate =
         tlsConf.hasPath("path_to_certificate")
@@ -161,11 +161,7 @@ public class XConfig {
         tlsConf.hasPath("path_to_private_key")
             ? readFromFile(Paths.get(tlsConf.getString("path_to_private_key")))
             : tlsConf.getString(DEFAULT_XRPC_PRIVATE_KEY);
-    return TlsConfig.builder()
-        .certificate(certificate)
-        .privateKey(privateKey)
-        .clientAuth(clientAuth)
-        .build();
+    return new TlsConfig(clientAuth, certificate, privateKey);
   }
 
   private CorsConfig buildCorsConfig(Config config) {

--- a/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/XConfig.java
@@ -50,6 +50,9 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 public class XConfig {
+  private static final String DEFAULT_XRPC_CERTIFICATE = "certificate";
+  private static final String DEFAULT_XRPC_PRIVATE_KEY = "private_key";
+
   private final int readerIdleTimeout;
   private final int writerIdleTimeout;
   private final int allIdleTimeout;
@@ -83,9 +86,6 @@ public class XConfig {
   private final int rateLimiterPoolSize;
 
   private final CorsConfig corsConfig;
-
-  private final String cert;
-  private final String key;
 
   /**
    * Construct a config object using the default configuration values <a
@@ -127,23 +127,6 @@ public class XConfig {
     adminRoutesEnableInfo = config.getBoolean("admin_routes.enable_info");
     adminRoutesEnableUnsafe = config.getBoolean("admin_routes.enable_unsafe");
     defaultContentType = config.getString("default_content_type");
-
-    // Check to see if path_to_cert and path_to_key are configured. If they are not configured,
-    // fall back to cert and key configured in plaintext in xrpc.conf.
-    if (config.hasPath("path_to_cert")) {
-      String pathToCert = config.getString("path_to_cert");
-      cert = readFromFile(Paths.get(pathToCert));
-    } else {
-      cert = config.getString("cert");
-    }
-
-    if (config.hasPath("path_to_key")) {
-      String pathToKey = config.getString("path_to_key");
-      key = readFromFile(Paths.get(pathToKey));
-    } else {
-      key = config.getString("key");
-    }
-
     globalSoftReqPerSec = config.getDouble("global_soft_req_per_sec");
     globalHardReqPerSec = config.getDouble("global_hard_req_per_sec");
     port = config.getInt("server.port");
@@ -152,7 +135,6 @@ public class XConfig {
     consoleReporter = config.getBoolean("console_reporter");
     slf4jReporterPollingRate = config.getInt("slf4j_reporter_polling_rate");
     consoleReporterPollingRate = config.getInt("console_reporter_polling_rate");
-
     enableWhiteList = config.getBoolean("enable_white_list");
     enableBlackList = config.getBoolean("enable_black_list");
 
@@ -174,11 +156,11 @@ public class XConfig {
     String certificate =
         tlsConf.hasPath("path_to_certificate")
             ? readFromFile(Paths.get(tlsConf.getString("path_to_certificate")))
-            : tlsConf.getString("certificate");
+            : tlsConf.getString(DEFAULT_XRPC_CERTIFICATE);
     String privateKey =
         tlsConf.hasPath("path_to_private_key")
             ? readFromFile(Paths.get(tlsConf.getString("path_to_private_key")))
-            : tlsConf.getString("private_key");
+            : tlsConf.getString(DEFAULT_XRPC_PRIVATE_KEY);
     return TlsConfig.builder()
         .certificate(certificate)
         .privateKey(privateKey)

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/Server.java
@@ -108,7 +108,7 @@ public class Server implements Routes {
   private Server(XConfig config, int port) {
     this.config = config;
     this.port = port >= 0 ? port : config.port();
-    this.tls = new Tls(config.cert(), config.key());
+    this.tls = new Tls(config.tlsConfig());
     this.healthCheckRegistry = new HealthCheckRegistry(config.asyncHealthCheckThreadCount());
 
     // This adds support for normal constructor binding.

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
@@ -164,6 +164,7 @@ public class Tls {
         kmf.init(keyStore, PASSWORD.toCharArray());
         sslCtx =
             SslContextBuilder.forServer(kmf)
+                .clientAuth(tlsConfig.getClientAuth())
                 .sslProvider(SslProvider.JDK)
                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                 .applicationProtocolConfig(

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
@@ -86,7 +86,7 @@ public class Tls {
 
       final List<java.security.cert.X509Certificate> certList = new ArrayList<>();
       final String rawCertString = tlsConfig.certificate();
-      final String key = tlsConfig.certificate();
+      final String key = tlsConfig.privateKey();
       PrivateKey privateKey;
       // PublicKey publicKey;
       // TODO(JR): Leave code in, we should really validate the signature with the public key

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/Tls.java
@@ -16,6 +16,7 @@
 
 package com.nordstrom.xrpc.server.tls;
 
+import com.google.common.base.Strings;
 import com.nordstrom.xrpc.XrpcConstants;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandler;
@@ -84,8 +85,8 @@ public class Tls {
     try {
 
       final List<java.security.cert.X509Certificate> certList = new ArrayList<>();
-      final String rawCertString = tlsConfig.getCertificate();
-      final String key = tlsConfig.getPrivateKey();
+      final String rawCertString = tlsConfig.certificate();
+      final String key = tlsConfig.certificate();
       PrivateKey privateKey;
       // PublicKey publicKey;
       // TODO(JR): Leave code in, we should really validate the signature with the public key
@@ -104,7 +105,7 @@ public class Tls {
 
       java.security.cert.X509Certificate[] chain;
 
-      if (tlsConfig.getCertificate() != null) {
+      if (!Strings.isNullOrEmpty(tlsConfig.certificate())) {
 
         String[] certs = rawCertString.split("-----END CERTIFICATE-----\n");
 
@@ -138,7 +139,7 @@ public class Tls {
         log.info("Using OpenSSL");
         sslCtx =
             SslContextBuilder.forServer(privateKey, chain)
-                .clientAuth(tlsConfig.getClientAuth())
+                .clientAuth(tlsConfig.clientAuth())
                 .sslProvider(SslProvider.OPENSSL)
                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                 .applicationProtocolConfig(
@@ -164,7 +165,7 @@ public class Tls {
         kmf.init(keyStore, PASSWORD.toCharArray());
         sslCtx =
             SslContextBuilder.forServer(kmf)
-                .clientAuth(tlsConfig.getClientAuth())
+                .clientAuth(tlsConfig.clientAuth())
                 .sslProvider(SslProvider.JDK)
                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                 .applicationProtocolConfig(

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
@@ -1,0 +1,13 @@
+package com.nordstrom.xrpc.server.tls;
+
+import io.netty.handler.ssl.ClientAuth;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TlsConfig {
+  private final ClientAuth clientAuth;
+  private final String certificate;
+  private final String privateKey;
+}

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
@@ -1,11 +1,13 @@
 package com.nordstrom.xrpc.server.tls;
 
 import io.netty.handler.ssl.ClientAuth;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.Value;
+import lombok.experimental.Accessors;
 
 @Getter
-@Builder
+@Value
+@Accessors(fluent = true)
 public class TlsConfig {
   private final ClientAuth clientAuth;
   private final String certificate;

--- a/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/server/tls/TlsConfig.java
@@ -1,11 +1,9 @@
 package com.nordstrom.xrpc.server.tls;
 
 import io.netty.handler.ssl.ClientAuth;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-@Getter
 @Value
 @Accessors(fluent = true)
 public class TlsConfig {

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -124,64 +124,9 @@ cors {
   short_circuit = false
 }
 
-# Path to x509 certificate to use for TLS. Set to the absolute path of a X509 certificate in UTF-8 encoded PEM format.
-# If this path and 'cert', below, are both configured, this path will be used and 'cert' will be ignored.
-# Throws a runtime error if a cert cannot be read from this path.
-#path_to_cert = "/path/to/cert.txt"
-
-# Path to private key to use for TLS. Set to the absolute path of an RSA private key in UTF-8 encoded PEM format.
-# If this path and 'key', below, are both configured, this path will be used and 'key' will be ignored.
-# Throws a runtime error if a key cannot be read from this path.
-#path_to_key = "/path/to/key.txt"
-
-# The raw X509 certificate to use for TLS.
-# This will only be used if path_to_cert, above, is not configured.
-cert = """
------BEGIN CERTIFICATE-----
-MIIDEDCCAnmgAwIBAgIJAO4gmvLYMMccMA0GCSqGSIb3DQEBBQUAMGQxCzAJBgNV
-BAYTAlVTMQswCQYDVQQIEwJJTDEQMA4GA1UEBxMHQ2hpY2FnbzENMAsGA1UEChME
-eGlvMjEMMAoGA1UECxMDZGV2MRkwFwYDVQQDExB4aW8yLmV4YW1wbGUuY29tMB4X
-DTE1MDgxMjE5MzUwOVoXDTE4MDYwMTE5MzUwOVowZDELMAkGA1UEBhMCVVMxCzAJ
-BgNVBAgTAklMMRAwDgYDVQQHEwdDaGljYWdvMQ0wCwYDVQQKEwR4aW8yMQwwCgYD
-VQQLEwNkZXYxGTAXBgNVBAMTEHhpbzIuZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcN
-AQEBBQADgY0AMIGJAoGBALE1ScG8WfneBnfo44uKgKEBTyMIoFW1SzQn3hkV8Pj/
-clF7wdRYruzwvL4FbvQWBzurRyUvjWyScdv9IecS0xXTmeJGlTfxhmdlhHVwdFQa
-Xd0cvJuotor/7cs0MxiWHPl/k7X/s846IDw7x/27I/Wh4Q3F+mT9oaljCd9hHn57
-AgMBAAGjgckwgcYwHQYDVR0OBBYEFP0sRxdfrg1yqo6Q9UdSlOcC4+v6MIGWBgNV
-HSMEgY4wgYuAFP0sRxdfrg1yqo6Q9UdSlOcC4+v6oWikZjBkMQswCQYDVQQGEwJV
-UzELMAkGA1UECBMCSUwxEDAOBgNVBAcTB0NoaWNhZ28xDTALBgNVBAoTBHhpbzIx
-DDAKBgNVBAsTA2RldjEZMBcGA1UEAxMQeGlvMi5leGFtcGxlLmNvbYIJAO4gmvLY
-MMccMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArIDxvkqZyWNdykA4
-6F5VdT64OvGsKb4mZNEF/nypq4U29w5f/JEAsp3jwVTqqI7Xgk7OeUXIyWJZBAga
-oq4hs6yvhrcLApdHoWI+2aOevtIh00P8QBmp4Ibbmh657ZWc3u8OsHGQ03ldpFXJ
-8eV4C/fb9jLnd/I1unwJULz1/vs=
------END CERTIFICATE-----
-"""
-
-# The private key to use for TLS.
-# This will only be used if path_to_key, above, is not configured.
-key = """
------BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCxNUnBvFn53gZ36OOLioChAU8jCKBVtUs0J94ZFfD4/3JRe8HU
-WK7s8Ly+BW70Fgc7q0clL41sknHb/SHnEtMV05niRpU38YZnZYR1cHRUGl3dHLyb
-qLaK/+3LNDMYlhz5f5O1/7POOiA8O8f9uyP1oeENxfpk/aGpYwnfYR5+ewIDAQAB
-AoGAY3sNz+PkAwCgUvp7mx+CvGAWxA0YrWTcNghXh2+o2q/UxmeaVZH/iWZQHsDA
-G+it4NJzWy3Jz/SaVKxTNvx7YKoEizihsw0aL1t9LaVqX3DWsp+ePRn1jxIxZqNe
-92Hrl9rACvM7caa7zLAiu9zcdl39zmIXvPXVHKn6O5AMx0ECQQDsD27iwSrk7vWW
-igxDtlIKy3T1WJB/fTI5lHbinAKL+mUO0NRQ/cVz/w0FuFN4VKYCcL15Kis7hGr2
-O5oNM0jbAkEAwC08mYS+TCHnLp1/KmPkog4yiBcWbM389nf+1OF1EZ9OvNC7A4IZ
-UcHVPB5uMYX4QlfsKHLolGQomnkpOLlC4QJAeRGBQXLo2Pllo4uxtpivgzHODncZ
-xQkk1Ts7rgVtmPUXF34rJk7BEjjhKOnchX6ElgPUaWwjOCc15Iu0+sguuQJAcMNa
-dp5MZzHRjCnAL2h0BJ8eCXq6ntdzok+gyNsOLWvz8Jjt004oey+oZmFYuVhp5sve
-d5GNZV0r8hA8HtueIQJBAJQR+eWTcwLga1vtn10RL1YfNqyC4fismcDbYXXJc1NI
-7W85HF8N9OzsxZEsYAt0ogTpg5UdHmGvv0mUZdTh0mU=
------END RSA PRIVATE KEY-----
-"""
-
-tls_config {
+tls {
   # The desired configuration of mutual authentication. Possible values "NONE", "OPTIONAL" or "REQUIRE"
   client_auth = "NONE"
-
 
   # Path to x509 certificate to use for TLS. Set to the absolute path of a X509 certificate in UTF-8 encoded PEM format.
   # If this path and 'cert', below, are both configured, this path will be used and 'cert' will be ignored.

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -179,6 +179,7 @@ d5GNZV0r8hA8HtueIQJBAJQR+eWTcwLga1vtn10RL1YfNqyC4fismcDbYXXJc1NI
 """
 
 tls_config {
+  # The desired configuration of mutual authentication. Possible values "NONE", "OPTIONAL" or "REQUIRE"
   client_auth = "NONE"
 
 

--- a/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
+++ b/xrpc/src/main/resources/com/nordstrom/xrpc/xrpc.conf
@@ -177,3 +177,62 @@ d5GNZV0r8hA8HtueIQJBAJQR+eWTcwLga1vtn10RL1YfNqyC4fismcDbYXXJc1NI
 7W85HF8N9OzsxZEsYAt0ogTpg5UdHmGvv0mUZdTh0mU=
 -----END RSA PRIVATE KEY-----
 """
+
+tls_config {
+  client_auth = "NONE"
+
+
+  # Path to x509 certificate to use for TLS. Set to the absolute path of a X509 certificate in UTF-8 encoded PEM format.
+  # If this path and 'cert', below, are both configured, this path will be used and 'cert' will be ignored.
+  # Throws a runtime error if a cert cannot be read from this path.
+  #path_to_certificate = "/path/to/cert.txt"
+
+  # Path to private key to use for TLS. Set to the absolute path of an RSA private key in UTF-8 encoded PEM format.
+  # If this path and 'key', below, are both configured, this path will be used and 'key' will be ignored.
+  # Throws a runtime error if a key cannot be read from this path.
+  #path_to_private_key = "/path/to/key.txt"
+
+  # The raw X509 certificate to use for TLS.
+  # This will only be used if path_to_cert, above, is not configured.
+  certificate = """
+-----BEGIN CERTIFICATE-----
+MIIDEDCCAnmgAwIBAgIJAO4gmvLYMMccMA0GCSqGSIb3DQEBBQUAMGQxCzAJBgNV
+BAYTAlVTMQswCQYDVQQIEwJJTDEQMA4GA1UEBxMHQ2hpY2FnbzENMAsGA1UEChME
+eGlvMjEMMAoGA1UECxMDZGV2MRkwFwYDVQQDExB4aW8yLmV4YW1wbGUuY29tMB4X
+DTE1MDgxMjE5MzUwOVoXDTE4MDYwMTE5MzUwOVowZDELMAkGA1UEBhMCVVMxCzAJ
+BgNVBAgTAklMMRAwDgYDVQQHEwdDaGljYWdvMQ0wCwYDVQQKEwR4aW8yMQwwCgYD
+VQQLEwNkZXYxGTAXBgNVBAMTEHhpbzIuZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcN
+AQEBBQADgY0AMIGJAoGBALE1ScG8WfneBnfo44uKgKEBTyMIoFW1SzQn3hkV8Pj/
+clF7wdRYruzwvL4FbvQWBzurRyUvjWyScdv9IecS0xXTmeJGlTfxhmdlhHVwdFQa
+Xd0cvJuotor/7cs0MxiWHPl/k7X/s846IDw7x/27I/Wh4Q3F+mT9oaljCd9hHn57
+AgMBAAGjgckwgcYwHQYDVR0OBBYEFP0sRxdfrg1yqo6Q9UdSlOcC4+v6MIGWBgNV
+HSMEgY4wgYuAFP0sRxdfrg1yqo6Q9UdSlOcC4+v6oWikZjBkMQswCQYDVQQGEwJV
+UzELMAkGA1UECBMCSUwxEDAOBgNVBAcTB0NoaWNhZ28xDTALBgNVBAoTBHhpbzIx
+DDAKBgNVBAsTA2RldjEZMBcGA1UEAxMQeGlvMi5leGFtcGxlLmNvbYIJAO4gmvLY
+MMccMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEArIDxvkqZyWNdykA4
+6F5VdT64OvGsKb4mZNEF/nypq4U29w5f/JEAsp3jwVTqqI7Xgk7OeUXIyWJZBAga
+oq4hs6yvhrcLApdHoWI+2aOevtIh00P8QBmp4Ibbmh657ZWc3u8OsHGQ03ldpFXJ
+8eV4C/fb9jLnd/I1unwJULz1/vs=
+-----END CERTIFICATE-----
+"""
+
+  # The private key to use for TLS.
+  # This will only be used if path_to_key, above, is not configured.
+  private_key = """
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCxNUnBvFn53gZ36OOLioChAU8jCKBVtUs0J94ZFfD4/3JRe8HU
+WK7s8Ly+BW70Fgc7q0clL41sknHb/SHnEtMV05niRpU38YZnZYR1cHRUGl3dHLyb
+qLaK/+3LNDMYlhz5f5O1/7POOiA8O8f9uyP1oeENxfpk/aGpYwnfYR5+ewIDAQAB
+AoGAY3sNz+PkAwCgUvp7mx+CvGAWxA0YrWTcNghXh2+o2q/UxmeaVZH/iWZQHsDA
+G+it4NJzWy3Jz/SaVKxTNvx7YKoEizihsw0aL1t9LaVqX3DWsp+ePRn1jxIxZqNe
+92Hrl9rACvM7caa7zLAiu9zcdl39zmIXvPXVHKn6O5AMx0ECQQDsD27iwSrk7vWW
+igxDtlIKy3T1WJB/fTI5lHbinAKL+mUO0NRQ/cVz/w0FuFN4VKYCcL15Kis7hGr2
+O5oNM0jbAkEAwC08mYS+TCHnLp1/KmPkog4yiBcWbM389nf+1OF1EZ9OvNC7A4IZ
+UcHVPB5uMYX4QlfsKHLolGQomnkpOLlC4QJAeRGBQXLo2Pllo4uxtpivgzHODncZ
+xQkk1Ts7rgVtmPUXF34rJk7BEjjhKOnchX6ElgPUaWwjOCc15Iu0+sguuQJAcMNa
+dp5MZzHRjCnAL2h0BJ8eCXq6ntdzok+gyNsOLWvz8Jjt004oey+oZmFYuVhp5sve
+d5GNZV0r8hA8HtueIQJBAJQR+eWTcwLga1vtn10RL1YfNqyC4fismcDbYXXJc1NI
+7W85HF8N9OzsxZEsYAt0ogTpg5UdHmGvv0mUZdTh0mU=
+-----END RSA PRIVATE KEY-----
+"""
+}

--- a/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
@@ -107,8 +107,8 @@ class XConfigTest {
 
   @Test
   void shouldSetDefaultTlsConfigValues() {
-    assertThat(config.tlsConfig().getClientAuth(), is(ClientAuth.NONE));
-    assertThat(config.tlsConfig().getCertificate(), matchesPattern(CERTIFICATE_REGEX));
-    assertThat(config.tlsConfig().getPrivateKey(), matchesPattern(PRIVATE_KEY_REGEX));
+    assertThat(config.tlsConfig().clientAuth(), is(ClientAuth.NONE));
+    assertThat(config.tlsConfig().certificate(), matchesPattern(CERTIFICATE_REGEX));
+    assertThat(config.tlsConfig().privateKey(), matchesPattern(PRIVATE_KEY_REGEX));
   }
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
@@ -16,8 +16,10 @@
 
 package com.nordstrom.xrpc;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,49 +67,49 @@ class XConfigTest {
 
   @Test
   void shouldSetDefaultXrpcConfigValues() {
+    assertEquals(TEN_MEGABYTES, config.maxPayloadBytes());
+    assertEquals(200 * SECONDS, config.readerIdleTimeout());
+    assertEquals(400 * SECONDS, config.writerIdleTimeout());
+    assertEquals(0, config.allIdleTimeout());
+    assertEquals("xrpc-worker-%d", config.workerNameFormat());
+    assertEquals(4, config.bossThreadCount());
+    assertEquals(40, config.workerThreadCount());
+    assertEquals(0, config.asyncHealthCheckThreadCount());
+    assertEquals(2000, config.maxConnections());
+    assertEquals(24, config.rateLimiterPoolSize());
+    assertEquals(500.0d, config.softReqPerSec());
+    assertEquals(550.0d, config.hardReqPerSec());
+    assertEquals(700.0d, config.globalSoftReqPerSec());
+    assertEquals(750.0d, config.globalHardReqPerSec());
+    assertEquals(
+        ImmutableMap.of("127.0.0.1", Arrays.asList(500d, 550d)),
+        config.getClientRateLimitOverride());
+    assertEquals(30 * SECONDS, config.slf4jReporterPollingRate());
+    assertEquals(30 * SECONDS, config.consoleReporterPollingRate());
+    assertEquals(NONE, config.ipBlackList());
+    assertEquals(NONE, config.ipWhiteList());
+    assertEquals("application/json", config.defaultContentType());
     assertThat(config.port(), is(8080));
-    assertThat(config.adminRoutesEnableInfo(), is(true));
-    assertThat(config.adminRoutesEnableUnsafe(), is(false));
-    assertThat(config.maxPayloadBytes(), is(TEN_MEGABYTES));
-    assertThat(config.readerIdleTimeout(), is(200 * SECONDS));
-    assertThat(config.writerIdleTimeout(), is(400 * SECONDS));
-    assertThat(config.allIdleTimeout(), is(0));
-    assertThat(config.workerNameFormat(), is("xrpc-worker-%d"));
-    assertThat(config.bossThreadCount(), is(4));
-    assertThat(config.workerThreadCount(), is(40));
-    assertThat(config.asyncHealthCheckThreadCount(), is(0));
-    assertThat(config.maxConnections(), is(2000));
-    assertThat(config.rateLimiterPoolSize(), is(24));
-    assertThat(config.softReqPerSec(), is(500.0d));
-    assertThat(config.hardReqPerSec(), is(550.0d));
-    assertThat(config.globalSoftReqPerSec(), is(700.0d));
-    assertThat(config.globalHardReqPerSec(), is(750.0d));
-    assertThat(
-        config.getClientRateLimitOverride(),
-        is(ImmutableMap.of("127.0.0.1", Arrays.asList(500d, 550d))));
-    assertThat(config.slf4jReporter(), is(false));
-    assertThat(config.slf4jReporterPollingRate(), is(30 * SECONDS));
-    assertThat(config.consoleReporter(), is(false));
-    assertThat(config.consoleReporterPollingRate(), is(30 * SECONDS));
-    assertThat(config.jmxReporter(), is(true));
-    assertThat(config.ipBlackList(), is(NONE));
-    assertThat(config.ipWhiteList(), is(NONE));
-    assertThat(config.defaultContentType(), is("application/json"));
+    assertTrue(config.adminRoutesEnableInfo());
+    assertTrue(config.jmxReporter());
+    assertFalse(config.slf4jReporter());
+    assertFalse(config.adminRoutesEnableUnsafe());
+    assertFalse(config.consoleReporter());
   }
 
   @Test
   void shouldSetDefaultCorsConfigValues() {
-    assertThat(config.corsConfig().isCorsSupportEnabled(), is(false));
-    assertThat(config.corsConfig().origins(), is(NONE));
-    assertThat(config.corsConfig().allowedRequestHeaders(), is(NONE));
-    assertThat(config.corsConfig().allowedRequestMethods(), is(NONE));
-    assertThat(config.corsConfig().isCredentialsAllowed(), is(false));
-    assertThat(config.corsConfig().isShortCircuit(), is(false));
+    assertEquals(NONE, config.corsConfig().origins());
+    assertEquals(NONE, config.corsConfig().allowedRequestHeaders());
+    assertEquals(NONE, config.corsConfig().allowedRequestMethods());
+    assertFalse(config.corsConfig().isCorsSupportEnabled());
+    assertFalse(config.corsConfig().isCredentialsAllowed());
+    assertFalse(config.corsConfig().isShortCircuit());
   }
 
   @Test
   void shouldSetDefaultTlsConfigValues() {
-    assertThat(config.tlsConfig().clientAuth(), is(ClientAuth.NONE));
+    assertEquals(ClientAuth.NONE, config.tlsConfig().clientAuth());
     assertThat(config.tlsConfig().certificate(), matchesPattern(CERTIFICATE_REGEX));
     assertThat(config.tlsConfig().privateKey(), matchesPattern(PRIVATE_KEY_REGEX));
   }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/XConfigTest.java
@@ -93,8 +93,6 @@ class XConfigTest {
     assertThat(config.ipBlackList(), is(NONE));
     assertThat(config.ipWhiteList(), is(NONE));
     assertThat(config.defaultContentType(), is("application/json"));
-    assertThat(config.cert(), matchesPattern(CERTIFICATE_REGEX));
-    assertThat(config.key(), matchesPattern(PRIVATE_KEY_REGEX));
   }
 
   @Test


### PR DESCRIPTION
* Added testing around default config values
* Extract TLS config into its own object. We should look at deprecating `path_to_cert`, `path_to_key`, `cert` and `key` in `XConfig` in favour of `TlsConfig`
* Decided to build our own TLS config instead of utilising some of the ones already available such as `com.xjeffrose.xio.SSL.TlsConfig` as we only want to be configuring values that are utilised within the server to avoid confusion.
* **BREAKING CHANGE** release required.

Migration: config will have to be updated to utilise `tls_config`:
**Old config**
```
path_to_cert = ${TLS_CERTIFICATE}
path_to_key = ${TLS_PRIVATE_KEY}
```
**New config**
```
tls_config {
    path_to_certificate = ${TLS_CERTIFICATE}
    path_to_private_key = ${TLS_PRIVATE_KEY}
}
```

For mutual auth to successfully work, this implementation requires that we add any custom CA's certs to the JRE's truststore (e.g. `keytool -importcert -alias new-ca -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -file new-ca.der`). We could extend TLS config to support passing in of trusted CAs.