### PR TITLE
Adds volume to pods

### DIFF
--- a/k8s-resources/deployment.yaml
+++ b/k8s-resources/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: xrpc
     spec:
+      volumes:
+      - name: netty-tmp-volume # Required for Netty to be able to export .so files under restrictive pod security policies
+        emptyDir: {}
       containers:
         - name: xrpc # Name of container. Can be same as app-name
           image: xrpc:1.0 # docker image with version tag
@@ -26,6 +29,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: netty-tmp-volume
           readinessProbe:           # Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails.
             httpGet:
               path: /health


### PR DESCRIPTION
Specifies an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume in deployment.yml, needed because when Netty fails to load at least one `netty_tcnative*` lib variant, it generates one (to `/tmp` by default, but configurable at start-up through `-Dio.netty.native.workdir`). This can't be done in a read-only file system, such as one in pods under a restricted [Pod Security Policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) with `ReadOnlyRootFilesystem: true` in k8s.

Mounting this volume as an `emptyDir` should solve this, unless the PSP forbids all use of volumes, or allows read-only volumes alone.