### PR TITLE
Fix RendezvousHash concurrent NPE

### DIFF
--- a/xrpc/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
@@ -22,7 +22,6 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BinaryOperator;
@@ -58,18 +57,18 @@ public class RendezvousHash<N> {
   }
 
   public N getOne(byte[] key) {
-    final Map<Long, N> nodeMap = generateHashToNodeMap(key);
+    final TreeMap<Long, N> nodeMap = generateOrderedNodeMapForKey(key);
 
-    return nodeMap.keySet().stream().max(Long::compare).map(nodeMap::get).orElse(null);
+    return nodeMap.descendingMap().values().stream().findFirst().orElse(null);
   }
 
   public List<N> get(byte[] key, int listSize) {
-    Map<Long, N> nodeMap = generateHashToNodeMap(key);
+    TreeMap<Long, N> nodeMap = generateOrderedNodeMapForKey(key);
 
-    return nodeMap.values().stream().limit(listSize).collect(Collectors.toList());
+    return nodeMap.descendingMap().values().stream().limit(listSize).collect(Collectors.toList());
   }
 
-  private TreeMap<Long, N> generateHashToNodeMap(byte[] key) {
+  private TreeMap<Long, N> generateOrderedNodeMapForKey(byte[] key) {
     return nodeList
         .stream()
         .collect(Collectors.toMap(keyMapper(key), node -> node, collisionHandler(), TreeMap::new));

--- a/xrpc/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
+++ b/xrpc/src/main/java/com/nordstrom/xrpc/RendezvousHash.java
@@ -61,12 +61,7 @@ public class RendezvousHash<N> {
 
     nodeList.forEach(xs -> addNodeToMap(key, hashMap, xs));
 
-    return hashMap
-      .keySet()
-      .stream()
-      .max(Long::compare) // find the largest key
-      .map(hashMap::get) // return node with the largest key
-      .orElse(null); // or return null if the map is empty
+    return hashMap.keySet().stream().max(Long::compare).map(hashMap::get).orElse(null);
   }
 
   public List<N> get(byte[] key, int listSize) {
@@ -88,13 +83,7 @@ public class RendezvousHash<N> {
   }
 
   private N addNodeToMap(byte[] key, Map<Long, N> nodeMap, N node) {
-    return nodeMap.put(
-      hasher
-        .newHasher()
-        .putBytes(key)
-        .putObject(node, nodeFunnel)
-        .hash()
-        .asLong(),
-      node);
+    long hash = hasher.newHasher().putBytes(key).putObject(node, nodeFunnel).hash().asLong();
+    return nodeMap.put(hash, node);
   }
 }

--- a/xrpc/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
@@ -63,9 +63,9 @@ class RendezvousHashTest {
     }
 
     Double averageMatchingHashesPerHost = hostToMatchingHashes.values().stream()
-      .mapToInt(List::size)
-      .average()
-      .orElse(-1);
+        .mapToInt(List::size)
+        .average()
+        .orElse(-1);
 
     int expectedAverage = hashesToMatch * totalGetsToRun / totalHosts;
     assertEquals(expectedAverage, averageMatchingHashesPerHost.intValue());
@@ -74,7 +74,7 @@ class RendezvousHashTest {
   @Test
   void shouldNotNullPointerWhileUsedConcurrently() throws InterruptedException {
     RendezvousHash<CharSequence> rendezvousHash = new RendezvousHash<>(
-      Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), Arrays.asList("hash1", "hash2")
+        Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), Arrays.asList("hash1", "hash2")
     );
 
     List<Object> errors = Collections.synchronizedList(new ArrayList<>());

--- a/xrpc/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
+++ b/xrpc/src/test/java/com/nordstrom/xrpc/RendezvousHashTest.java
@@ -18,48 +18,91 @@ package com.nordstrom.xrpc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Funnels;
 import io.netty.util.internal.PlatformDependent;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 class RendezvousHashTest {
+
+  public static final int MAX_RANDOM_NUMBER = 123456789;
+
   @Test
-  public void get() throws Exception {
-    List<String> nodeList = new ArrayList<>();
-    Map<String, List<String>> mm = PlatformDependent.newConcurrentHashMap();
-    for (int i = 0; i < 100; i++) {
-      nodeList.add(("Host" + i));
-      mm.put(("Host" + i), new ArrayList<>());
+  public void get_shouldReturnExpectedNumberOfHashesOnAllRuns() throws Exception {
+    List<String> hostList = new ArrayList<>();
+    Map<String, List<String>> hostToMatchingHashes = PlatformDependent.newConcurrentHashMap();
+    int totalHosts = 100;
+    for (int i = 0; i < totalHosts; i++) {
+      hostList.add(("Host" + i));
+      hostToMatchingHashes.put(("Host" + i), new ArrayList<>());
     }
 
     RendezvousHash<CharSequence> rendezvousHash =
-        new RendezvousHash<>(Funnels.stringFunnel(Charset.defaultCharset()), nodeList);
-    Random r = new Random();
-    for (int i = 0; i < 100000; i++) {
-      String thing = (Integer.toString(r.nextInt(123456789)));
-      List<CharSequence> hosts = rendezvousHash.get(thing.getBytes(), 3);
-      hosts.forEach(
-          xs -> {
-            mm.get(xs).add(thing);
-          });
+        new RendezvousHash<>(Funnels.stringFunnel(Charset.defaultCharset()), hostList);
+
+    int totalGetsToRun = 100000;
+    int hashesToMatch = 3;
+    Random random = new Random();
+    for (int i = 0; i < totalGetsToRun; i++) {
+      String randomNumberString = (Integer.toString(random.nextInt(MAX_RANDOM_NUMBER)));
+      List<CharSequence> hosts = rendezvousHash.get(randomNumberString.getBytes(), hashesToMatch);
+      hosts.forEach(host -> hostToMatchingHashes.get(host).add(randomNumberString));
     }
 
-    List<Integer> xx = new ArrayList<>();
-    mm.keySet()
-        .forEach(
-            xs -> {
-              xx.add(mm.get(xs).size());
-            });
+    Double averageMatchingHashesPerHost = hostToMatchingHashes.values().stream()
+      .mapToInt(List::size)
+      .average()
+      .orElse(-1);
 
-    Double xd = xx.stream().mapToInt(x -> x).average().orElse(-1);
-    assertEquals(3000, xd.intValue());
+    int expectedAverage = hashesToMatch * totalGetsToRun / totalHosts;
+    assertEquals(expectedAverage, averageMatchingHashesPerHost.intValue());
+  }
+
+  @Test
+  void shouldNotNullPointerWhileUsedConcurrently() throws InterruptedException {
+    RendezvousHash<CharSequence> rendezvousHash = new RendezvousHash<>(
+      Funnels.stringFunnel(XrpcConstants.DEFAULT_CHARSET), Arrays.asList("hash1", "hash2")
+    );
+
+    List<Object> errors = Collections.synchronizedList(new ArrayList<>());
+
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    IntStream.range(0, 100).forEach(i -> {
+      executorService.submit(() -> {
+        try {
+          rendezvousHash.get("hash1".getBytes(), 2);
+        } catch (NullPointerException e) {
+          errors.add(e);
+        }
+      });
+
+      executorService.submit(() -> {
+        try {
+          rendezvousHash.getOne("hash1".getBytes());
+        } catch (NullPointerException e) {
+          errors.add(e);
+        }
+      });
+    });
+
+    executorService.shutdown();
+    executorService.awaitTermination(1, TimeUnit.SECONDS);
+
+    assertTrue(errors.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Resolves #203 -- many thanks to @manimaul for the report!

#### Context
~6% of all requests are currently failing to resolve due to a concurrency NPE in `ServerRateLimiter`'s `RendezvousHash`. The NPE occurs whenever multiple methods reset and populate a `RendezvousHash`'s internal hashmap at the same.

This MR resolves the issue by no longer using a shared map and instead creating new instances on each call. Also includes some small refactors for clarity and a new testcase to help prevent regressions. The new test fails consistently with the original `RendezvousHash` code.

You can see from the performance regression script that current master fails with socket errors in 1912 / 32720 requests while this branch fails 0 / 76753.

#### Regression on master:
<img width="461" alt="screen shot 2018-11-29 at 6 52 26 pm" src="https://user-images.githubusercontent.com/20407241/49266088-aaaabf80-f409-11e8-8e65-912ac2479e80.png">

#### Regression with branch:
<img width="464" alt="screen shot 2018-11-29 at 6 49 40 pm" src="https://user-images.githubusercontent.com/20407241/49266102-b1393700-f409-11e8-83c6-3ced389f2669.png">

